### PR TITLE
fix improved fiends installation without smarter mages

### DIFF
--- a/BiG World Fixpack/stratagems/fiend.tpa.patch
+++ b/BiG World Fixpack/stratagems/fiend.tpa.patch
@@ -1,0 +1,12 @@
+--- stratagems/fiend/fiend.tpa	2017-01-19 03:38:00.000000000 +0700
++++ Fixpack/stratagems/fiend/fiend.tpa	2017-01-19 04:18:22.000000000 +0700
+@@ -376,6 +376,9 @@
+ 
+    // correct the Guarded-Compound summonings
+ 
++   ACTION_IF !FILE_EXISTS_IN_GAME ~dw#sumgl.spl~ BEGIN
++     LAF clone_spell STR_VAR spell=~%WIZARD_MORDENKAINENS_SWORD%=>dw#sumgl~ END
++   END
+    LAF clone_spell STR_VAR spell="dw#sumgl=>dw#gcglb" END
+    LAF swap_text STR_VAR files=kettaatk.bcs swaps=~ForceSpell(LastTrigger(Myself),WIZARD_SUMMON_FIEND)=>ForceSpellRES("dw#gcglb",LastTrigger(Myself))~ END
+ 


### PR DESCRIPTION
Hi, this is a fix for Improved Fiends failing to install as reported [on shsforums](http://www.shsforums.net/topic/58624-bwsstratagems-resource-dw-sumglspl-not-found-for-copy/).
The reason is that it relies on Smarter Mages to be installed previously.