### PR TITLE
Make patches that use paths with backslashes, work on Linux and Mac.

### DIFF
--- a/BiG World Fixpack/_utils/trans_crlf.sh
+++ b/BiG World Fixpack/_utils/trans_crlf.sh
@@ -1,6 +1,11 @@
 #!/bin/bash
 patchfile=$1
 
+# Replace \ with / in paths listed in the patch:
+awk '/^--- (.*)/ { gsub("\\\\", "/") } { print }' "$patchfile" > "$patchfile.tmp"
+mv -f "$patchfile.tmp" "$patchfile"
+
+# Inside each file specified by such a path, translate CRLF->LF:
 files=($(awk '/^--- / {print $2}' $patchfile))
 for filename in ${files[*]};
 do

--- a/_ApplyPatches.tp2
+++ b/_ApplyPatches.tp2
@@ -342,6 +342,9 @@ ALWAYS
 			ACTION_IF (FILE_EXISTS ~%source_folder%/%TARGET_FILE%~) THEN BEGIN
 				SILENT // suppress "copying 1 file..." log message
 				COPY - ~%source_folder%/%TARGET_FILE%~ ~%FIXPACK%/tmpfile~ // fake copy
+					PATCH_IF !(~%WEIDU_OS%~ STR_EQ ~win32~) BEGIN  // fix the path on Mac & Linux
+						REPLACE_TEXTUALLY EXACT_MATCH ~\~ ~/~
+					END
 					READ_2DA_ENTRY 0 0 1 copy_target_folder // top-level mod directory name
 				BUT_ONLY
 				VERBOSE
@@ -356,6 +359,9 @@ ALWAYS
 		ACTION_IF (FILE_EXISTS ~%source_folder%/%DEL_FILE%~) THEN BEGIN
 			SILENT // suppress "copying 1 file..." log message
 			COPY - ~%source_folder%/%DEL_FILE%~ ~%FIXPACK%/tmpfile~ // fake copy
+				PATCH_IF !(~%WEIDU_OS%~ STR_EQ ~win32~) BEGIN  // fix paths on Mac & Linux
+					REPLACE_TEXTUALLY EXACT_MATCH ~\~ ~/~
+				END
 				COUNT_2DA_ROWS 1 num_files // 1 column
 				PATCH_IF (num_files > 0) THEN BEGIN
 					PATCH_PRINT ~deleting files ...~
@@ -392,6 +398,9 @@ ALWAYS
 		ACTION_IF (FILE_EXISTS ~%source_folder%/%REN_FILE%~) THEN BEGIN
 			SILENT // suppress "copying 1 file..." log message
 			COPY - ~%source_folder%/%REN_FILE%~ ~%FIXPACK%/tmpfile~ // fake copy
+				PATCH_IF !(~%WEIDU_OS%~ STR_EQ ~win32~) BEGIN  // fix paths on Mac & Linux
+					REPLACE_TEXTUALLY EXACT_MATCH ~\~ ~/~
+				END
 				COUNT_2DA_ROWS 2 num_files // 2 columns
 				PATCH_IF (num_files > 0) THEN BEGIN
 					PATCH_PRINT ~renaming files ...~


### PR DESCRIPTION
Many `*.patch`, `_delete`, `_rename`, etc. files contain paths with
backslashes as directory separators. That's fine on Windows, but
prevents those patches from working on Linux and probably also Mac.
(See issue #22.)

This commit makes `_ApplyPatches.tp2` substitute forward slashes for
those backslashes in the relevant places, when not running on
Windows.

I tested the fix on Linux, but it should also work on Mac.
Windows users shouldn't be affected at all.