### PR TITLE
stratagems: Fix mangled patch

### DIFF
--- a/BiG World Fixpack/stratagems/_depends/spell_rev/attacks_on_PC_defences.ssl.patch
+++ b/BiG World Fixpack/stratagems/_depends/spell_rev/attacks_on_PC_defences.ssl.patch
@@ -18,7 +18,26 @@
  THEN DO
  	Combine()
  	SetGlobalTimer("DMWW_dispel","LOCALS",18)
-tatGT(scstarget,-10,SAVEVSSPELL) // a rough indicator of a potion of Magic Shielding
+--- stratagems/mage/ssl/bg2/combatblocks/attacks_on_pc_defences.ssl	2016-11-20 18:27:15.402473500 -0500
++++ Fixpack/stratagems/mage/ssl/bg2/combatblocks/attacks_on_pc_defences.ssl	2016-12-01 15:11:46.505884400 -0500
+@@ -14,7 +14,7 @@
+ IF TRIGGER
+ 	IgnoreBlock(Indiscriminate)
+ 	TargetBlock(PCsInOrder)
+-	TriggerBlock(SpellTurn|SIAbjuration|Enemy|Helpless)
++	TriggerBlock(SpellTurn|SpellTurnNew|Enemy|Helpless)
+ 	CheckStatGT(scstarget,99,MAGICDAMAGERESISTANCE)
+ 	HaveSpell(WIZARD_ABI_DALZIMS_HORRID_WILTING)
+ 	RequireBlock(HasL8)
+@@ -40,12 +40,13 @@
+ IF TRIGGER
+ 	IgnoreBlock(Indiscriminate)
+ 	TargetBlock(PCsInOrder)
+-	TriggerBlock(SpellTurn|SIAbjuration|Enemy|Helpless)
+-	OR(4)
++	TriggerBlock(SpellTurn|SpellTurnNew|Enemy|Helpless)
++	OR(5)
+ 		!CheckStatGT(scstarget,-10,SAVEVSSPELL) // a rough indicator of a potion of Magic Shielding
  		CheckStatGT(scstarget,0,CLERIC_CHAOTIC_COMMANDS)
  		CheckStatGT(scstarget,0,WIZARD_PROTECTION_FROM_MAGIC_WEAPONS)
  		CheckStatGT(scstarget,2,STONESKINS)


### PR DESCRIPTION
Something must have gone very wrong when this patch file was created, because instead of listing the two sections for the two target files one below the other, the section for the `/bg1/` file *replaced* the beginning of the section for the `/bg2/` file.  
The result was a broken patch which the `patch` utility rejected.

I reconstructed the patch file from its sources ([here](http://gibberlings3.net/forums/index.php?app=downloads&showfile=914) and [here](http://gibberlings3.net/forums/index.php?showtopic=28249)); now it applies cleanly.

I tested that the Smarter Mages component (which this is part of) installs fine with this commit.

---

I looked through the remaining SCS patch files with the help of some shell scripting to see if more of them were mangled in a similar way, but from what I can tell this was the only one.

It looks like the mangled patch file was added by @agb1 in [this massive commit](https://github.com/BiGWorldProject/BiG-World-Fixpack/commit/b73cec4324d36aa9782f01693897a838c83a9020#diff-088aa7b2a87b7faba99ceecdfce763b6) which added 157 files to the Fixpack; did he use the `_ApplyPatches.tp2` script to generate them, and if so does that mean this script is not safe to use?