### PR TITLE
1pp-fixes-1.03b

### DIFF
--- a/BiG World Fixpack/1pp/200_1ppv2_cut.tph.patch
+++ b/BiG World Fixpack/1pp/200_1ppv2_cut.tph.patch
@@ -1,5 +1,5 @@
 --- 1pp\install\200_1ppv2_cut.tph	2011-05-01 19:02:59.250000000 -0500
-+++ C:\Users\Bartimaeus\Desktop\1pp\install\200_1ppv2_cut.tph	2017-07-22 13:53:30.358151000 -0500
++++ E:\Backups\Games\Baldur's Gate II\Tools\Directory Override\1pp\install\200_1ppv2_cut.tph	2018-02-08 13:03:42.138617600 -0600
 @@ -29,7 +29,7 @@
    BUT_ONLY_IF_IT_CHANGES
    END
@@ -31,7 +31,33 @@
    
    
      ACTION_IF (FILE_EXISTS_IN_GAME ~demosum4.itm~) THEN BEGIN
-@@ -1421,7 +1421,7 @@
+@@ -97,7 +97,7 @@
+     ACTION_IF (FILE_EXISTS_IN_GAME ~halb07.itm~) THEN BEGIN
+   COPY_EXISTING ~halb07.itm~ ~override~
+   WRITE_LONG  0x3E 0
+-  WRITE_ASCII 0x3A ~ihalb03~
++  WRITE_ASCII 0x3A ~ihalb07~
+   READ_LONG  0x6a "gfx_off"
+   READ_SHORT 0x70 "gfx_num"
+   WHILE ("%gfx_num%" > 0) BEGIN
+@@ -242,14 +242,14 @@
+     ACTION_IF (FILE_EXISTS_IN_GAME ~%item%.itm~) THEN BEGIN
+       COPY_EXISTING ~%item%.itm~ ~override~
+   WRITE_LONG  0x3E 0
+-  WRITE_ASCII 0x3A ~ISW1HRN~
++  WRITE_ASCII 0x3A ~ISW1H06~
+   READ_LONG  0x64 "abil_off"
+   READ_SHORT 0x68 "abil_num"
+   WHILE ("%abil_num%" > 0) BEGIN
+     READ_BYTE ("%abil_off%" + (0x38 * ("%abil_num%" - 1))) "type"
+     PATCH_IF ("%type%" = 1) BEGIN
+       WRITE_LONG  ("%abil_off%" + 0x08 + (0x38 * ("%abil_num%" - 1))) 0
+-      WRITE_ASCII ("%abil_off%" + 0x04 + (0x38 * ("%abil_num%" - 1))) ~ISW1HRN~
++      WRITE_ASCII ("%abil_off%" + 0x04 + (0x38 * ("%abil_num%" - 1))) ~ISW1H06~
+     END
+     SET "abil_num" = ("%abil_num%" - 1)
+   END
+@@ -1421,51 +1421,51 @@
    BUT_ONLY_IF_IT_CHANGES
  END
    
@@ -39,8 +65,19 @@
 +/*      ACTION_IF (FILE_EXISTS_IN_GAME ~sw1h31.itm~) THEN BEGIN //Daystar's icon being set to Albruin's for no apparent reason
  COPY_EXISTING ~sw1h31.itm~ ~override~
    WRITE_LONG  0x3E 0
-   WRITE_ASCII 0x3A ~ISW1H34~
-@@ -1438,7 +1438,7 @@
+-  WRITE_ASCII 0x3A ~ISW1H34~
++  WRITE_ASCII 0x3A ~ISW1H31~
+   READ_LONG  0x64 "abil_off"
+   READ_SHORT 0x68 "abil_num"
+   WHILE ("%abil_num%" > 0) BEGIN
+     READ_BYTE ("%abil_off%" + (0x38 * ("%abil_num%" - 1))) "type"
+     PATCH_IF ("%type%" = 1) BEGIN
+       WRITE_LONG  ("%abil_off%" + 0x08 + (0x38 * ("%abil_num%" - 1))) 0
+-      WRITE_ASCII ("%abil_off%" + 0x04 + (0x38 * ("%abil_num%" - 1))) ~ISW1H34~
++      WRITE_ASCII ("%abil_off%" + 0x04 + (0x38 * ("%abil_num%" - 1))) ~ISW1H31~
+     END
+     SET "abil_num" = ("%abil_num%" - 1)
+   END
    BUT_ONLY_IF_IT_CHANGES
  END
    
@@ -48,8 +85,17 @@
 +      ACTION_IF (FILE_EXISTS_IN_GAME ~sw1h34.itm~) THEN BEGIN //Albruin's icon being set to Daystar's for no apparent reason
  COPY_EXISTING ~sw1h34.itm~ ~override~
    WRITE_LONG  0x3E 0
-   WRITE_ASCII 0x3A ~ISW1H31~
-@@ -1453,7 +1453,7 @@
+-  WRITE_ASCII 0x3A ~ISW1H31~
++  WRITE_ASCII 0x3A ~ISW1H34~
+   READ_LONG  0x64 "abil_off"
+   READ_SHORT 0x68 "abil_num"
+   WHILE ("%abil_num%" > 0) BEGIN
+     READ_BYTE ("%abil_off%" + (0x38 * ("%abil_num%" - 1))) "type"
+     PATCH_IF ("%type%" = 1) BEGIN
+       WRITE_LONG  ("%abil_off%" + 0x08 + (0x38 * ("%abil_num%" - 1))) 0
+-      WRITE_ASCII ("%abil_off%" + 0x04 + (0x38 * ("%abil_num%" - 1))) ~ISW1H31~
++      WRITE_ASCII ("%abil_off%" + 0x04 + (0x38 * ("%abil_num%" - 1))) ~ISW1H34~
+     END
      SET "abil_num" = ("%abil_num%" - 1)
    END
    BUT_ONLY_IF_IT_CHANGES
@@ -58,6 +104,77 @@
    
        ACTION_IF (FILE_EXISTS_IN_GAME ~sw1h41.itm~) THEN BEGIN
  COPY_EXISTING ~sw1h41.itm~ ~override~
+   WRITE_LONG  0x3E 0
+-  WRITE_ASCII 0x3A ~ISW1H06~
++  WRITE_ASCII 0x3A ~ISW1H41~
+   READ_LONG  0x64 "abil_off"
+   READ_SHORT 0x68 "abil_num"
+   WHILE ("%abil_num%" > 0) BEGIN
+     READ_BYTE ("%abil_off%" + (0x38 * ("%abil_num%" - 1))) "type"
+     PATCH_IF ("%type%" = 1) BEGIN
+       WRITE_LONG  ("%abil_off%" + 0x08 + (0x38 * ("%abil_num%" - 1))) 0
+-      WRITE_ASCII ("%abil_off%" + 0x04 + (0x38 * ("%abil_num%" - 1))) ~ISW1H06~
++      WRITE_ASCII ("%abil_off%" + 0x04 + (0x38 * ("%abil_num%" - 1))) ~ISW1H41~
+     END
+     SET "abil_num" = ("%abil_num%" - 1)
+   END
+@@ -1603,19 +1603,19 @@
+   BUT_ONLY_IF_IT_CHANGES
+ END
+   
+-  ACTION_FOR_EACH ~item~ IN ~sw2h10~ ~sw2h19~    BEGIN
++  ACTION_FOR_EACH ~item~ IN ~sw2h10~ ~sw2h19~    BEGIN //Why was this being set to ISW2H20? ...
+     ACTION_IF (FILE_EXISTS_IN_GAME ~%item%.itm~) THEN BEGIN
+       COPY_EXISTING ~%item%.itm~ ~override~
+   PATCH_IF (SOURCE_SIZE > 0x71) THEN BEGIN // protects against invalid files
+     WRITE_LONG  0x3E 0
+-    WRITE_ASCII 0x3A ~ISW2H20~
++    WRITE_ASCII 0x3A ~ISW2H10~
+     READ_LONG  0x64 "abil_off"
+     READ_SHORT 0x68 "abil_num"
+     WHILE ("%abil_num%" > 0) BEGIN
+       READ_BYTE ("%abil_off%" + (0x38 * ("%abil_num%" - 1))) "type"
+       PATCH_IF ("%type%" = 1) BEGIN
+         WRITE_LONG  ("%abil_off%" + 0x08 + (0x38 * ("%abil_num%" - 1))) 0
+-        WRITE_ASCII ("%abil_off%" + 0x04 + (0x38 * ("%abil_num%" - 1))) ~ISW2H20~
++        WRITE_ASCII ("%abil_off%" + 0x04 + (0x38 * ("%abil_num%" - 1))) ~ISW2H10~
+       END
+       SET "abil_num" = ("%abil_num%" - 1)
+     END
+@@ -1627,14 +1627,14 @@
+    ACTION_IF (FILE_EXISTS_IN_GAME ~sw2h11.itm~) THEN BEGIN
+ COPY_EXISTING ~sw2h11.itm~ ~override~
+   WRITE_LONG  0x3E 0
+-  WRITE_ASCII 0x3A ~ISW2H03~
++  WRITE_ASCII 0x3A ~ISW2H11~
+   READ_LONG  0x64 "abil_off"
+   READ_SHORT 0x68 "abil_num"
+   WHILE ("%abil_num%" > 0) BEGIN
+     READ_BYTE ("%abil_off%" + (0x38 * ("%abil_num%" - 1))) "type"
+     PATCH_IF ("%type%" = 1) BEGIN
+       WRITE_LONG  ("%abil_off%" + 0x08 + (0x38 * ("%abil_num%" - 1))) 0
+-      WRITE_ASCII ("%abil_off%" + 0x04 + (0x38 * ("%abil_num%" - 1))) ~ISW2H03~
++      WRITE_ASCII ("%abil_off%" + 0x04 + (0x38 * ("%abil_num%" - 1))) ~ISW2H11~
+     END
+     SET "abil_num" = ("%abil_num%" - 1)
+   END
+@@ -1645,14 +1645,14 @@
+ COPY_EXISTING ~sw2h20.itm~ ~override~
+   PATCH_IF (SOURCE_SIZE > 0x71) THEN BEGIN // protects against invalid files
+     WRITE_LONG  0x3E 0
+-    WRITE_ASCII 0x3A ~ISW2H06~
++    WRITE_ASCII 0x3A ~ISW2H20~
+     READ_LONG  0x64 "abil_off"
+     READ_SHORT 0x68 "abil_num"
+     WHILE ("%abil_num%" > 0) BEGIN
+       READ_BYTE ("%abil_off%" + (0x38 * ("%abil_num%" - 1))) "type"
+       PATCH_IF ("%type%" = 1) BEGIN
+         WRITE_LONG  ("%abil_off%" + 0x08 + (0x38 * ("%abil_num%" - 1))) 0
+-        WRITE_ASCII ("%abil_off%" + 0x04 + (0x38 * ("%abil_num%" - 1))) ~ISW2H06~
++        WRITE_ASCII ("%abil_off%" + 0x04 + (0x38 * ("%abil_num%" - 1))) ~ISW2H20~
+       END
+       SET "abil_num" = ("%abil_num%" - 1)
+     END
 @@ -1666,14 +1666,14 @@
  COPY ~1pp/item/v2_copy/cshld19.bam~  ~override~
  COPY ~1pp/item/v2_copy/cshld20.bam~  ~override~
@@ -71,16 +188,59 @@
  COPY ~1pp/item/v2_copy/iblun26.bam~  ~override~
  COPY ~1pp/item/v2_copy/ibolts01.bam~ ~override~
 -COPY ~1pp/item/v2_copy/ibow26.bam~ ~override~
-+COPY ~1pp/item/v2_copy/ibow26.bam~ ~override~ //Short Bow +3 getting weird IWD icon
++//COPY ~1pp/item/v2_copy/ibow26.bam~ ~ibow26b.bam~ //Short Bow +3 getting weird IWD icon
  COPY ~1pp/item/v2_copy/ichan04.bam~  ~override~
  COPY ~1pp/item/v2_copy/ichan05.bam~  ~override~
  COPY ~1pp/item/v2_copy/ichan07.bam~  ~override~
-@@ -1701,7 +1701,7 @@
+@@ -1690,18 +1690,18 @@
+ COPY ~1pp/item/v2_copy/iclck15.bam~  ~override~
+ COPY ~1pp/item/v2_copy/iclck16.bam~  ~override~
+ COPY ~1pp/item/v2_copy/iclck17.bam~  ~override~
+-COPY ~1pp/item/v2_copy/idagg11.bam~  ~override~
++//COPY ~1pp/item/v2_copy/idagg11.bam~  ~override~ //Overwriting Boomerang Dagger's icon with Dagger of Venom's for no reason
+ COPY ~1pp/item/v2_copy/ihalb03.bam~  ~override~
+ COPY ~1pp/item/v2_copy/ihalb10.bam~  ~override~
+ COPY ~1pp/item/v2_copy/ihalb12.bam~  ~override~
+-COPY ~1pp/item/v2_copy/ihamm10.bam~  ~override~
++COPY ~1pp/item/v2_copy/ihamm10.bam~  ~override/ihamm11.bam~ //Save vanilla's Runehammer icon
+ COPY ~1pp/item/v2_copy/ihelm00.bam~  ~override~
+ COPY ~1pp/item/v2_copy/ihelm01.bam~  ~override~
+ COPY ~1pp/item/v2_copy/ihelm02.bam~  ~override~
  COPY ~1pp/item/v2_copy/ihelm03.bam~  ~override~
  COPY ~1pp/item/v2_copy/ihelm04.bam~  ~override~
  COPY ~1pp/item/v2_copy/ihelm05.bam~  ~override~
 -COPY ~1pp/item/v2_copy/ihelm06.bam~  ~override~
-+//COPY ~1pp/item/v2_copy/ihelm06.bam~  ~override~ //Roranach's Horn getting weird IWD graphic
++//COPY ~1pp/item/v2_copy/ihelm06.bam~  ~override~ //Roranach's Horn getting weird IWD icon
  COPY ~1pp/item/v2_copy/ihelm07.bam~  ~override~
  COPY ~1pp/item/v2_copy/ihelm14.bam~  ~override~
  COPY ~1pp/item/v2_copy/ihelm31.bam~  ~override~
+@@ -1709,7 +1709,7 @@
+ COPY ~1pp/item/v2_copy/ileat01.bam~  ~override~
+ COPY ~1pp/item/v2_copy/ileat04.bam~  ~override~
+ COPY ~1pp/item/v2_copy/iplat01.bam~  ~override~
+-COPY ~1pp/item/v2_copy/iplat09.bam~  ~override~
++COPY ~1pp/item/v2_copy/iplat09.bam~  ~override/1plat02.bam~
+ COPY ~1pp/item/v2_copy/iplot01f.bam~ ~override~
+ COPY ~1pp/item/v2_copy/iqbull02.bam~ ~override~
+ COPY ~1pp/item/v2_copy/iquiv01.bam~  ~override~
+@@ -1723,7 +1723,7 @@
+ COPY ~1pp/item/v2_copy/ishldvr.bam~  ~override~
+ COPY ~1pp/item/v2_copy/ishldzs.bam~  ~override~
+ COPY ~1pp/item/v2_copy/isw1h02.bam~  ~override~
+-COPY ~1pp/item/v2_copy/isw1h06.bam~  ~override~
++//COPY ~1pp/item/v2_copy/isw1h06.bam~  ~override~ //Unnecessary overwrite - duplicate of isw1h72
+ COPY ~1pp/item/v2_copy/isw1h16.bam~  ~override~
+ COPY ~1pp/item/v2_copy/isw1h42.bam~  ~override~
+ COPY ~1pp/item/v2_copy/isw1h51.bam~  ~override~
+@@ -1749,9 +1749,9 @@
+ COPY ~1pp/item/v2_copy/isw1h77.bam~  ~override~
+ COPY ~1pp/item/v2_copy/isw1hbs.bam~  ~override~
+ COPY ~1pp/item/v2_copy/isw1hrc.bam~  ~override~
+-COPY ~1pp/item/v2_copy/isw1hrn.bam~  ~override~
++COPY ~1pp/item/v2_copy/isw1hrn.bam~  ~override/isw1h06.bam~ //Original place
+ COPY ~1pp/item/v2_copy/isw1hwk.bam~  ~override~
+-COPY ~1pp/item/v2_copy/isw2h07.bam~  ~override~
++COPY ~1pp/item/v2_copy/isw2h07.bam~  ~override/isw2h16.bam~ //Prevent Harbinger from losing its golden icon (which is what it's colored for anyway)
+ COPY ~1pp/item/v2_copy/isw2h17.bam~  ~override~
+ COPY ~1pp/item/v2_copy/isw2h20.bam~  ~override~
+ COPY ~1pp/item/v2_copy/iwand01.bam~  ~override~

--- a/BiG World Fixpack/1pp/400_1pp_update_bgii.tph.patch
+++ b/BiG World Fixpack/1pp/400_1pp_update_bgii.tph.patch
@@ -1,1259 +1,247 @@
 --- 1pp\install\400_1pp_update_bgii.tph	2012-09-20 05:25:37.107715600 -0500
-+++ E:\Backups\Games\Baldur's Gate II\Tools\Directory Override\1pp\install\400_1pp_update_bgii.tph	2018-01-07 03:22:16.215648500 -0600
-@@ -29,10 +29,12 @@
- 
- PRINT ~Copying resources...~
- 
--ACTION_FOR_EACH resource IN ~1amul07B~ ~1amul07C~ ~1band01~ ~1band02~ ~1band03~ ~1band04~ ~1band05~ ~1band06~ ~1BOLTS01~ ~1BOLTS02~ ~1chan01B~ ~1chan02B~ ~1chan03B~ ~1chan04B~ ~1clck07B~ ~1clck27B~ ~1CSTAFM~ ~1GLEAT01~ ~1GSTAFGS~ ~1helm00~ ~1helm01~ ~1helm02~ ~1helm03~ ~1helm04~ ~1helm05~ ~1helm06~ ~1helm07~ ~1helm08~ ~1helm09~ ~1helm10~ ~1helm11~ ~1helm12~ ~1helm13~ ~1helm14~ ~1helm15~ ~1helm16~ ~1helm17~ ~1helm18~ ~1helm19~ ~1helm20~ ~1helm21~ ~1helm22~ ~1helm23~ ~1helm24~ ~1helm25~ ~1helm26~ ~1leat02~ ~1LEAT05~ ~1LEAT06~ ~1LEAT07~ ~1LEAT08~ ~1LEAT10~ ~1PLAT02~ ~1PLAT04~ ~1PLAT05~ ~1plat13~ ~1plat18B~ ~1plat23B~ ~1QBULL02~ ~1QBULL03~ ~1QUIV01~ ~1QUIV02~ ~1shld172~ ~1shldl01~ ~1shldl02~ ~1shldl03~ ~1shldl04~ ~1shldl05~ ~1shldm01~ ~1shldm02~ ~1shldm03~ ~1shldm04~ ~1swh00~ ~GBOW02~ ~GBSHLD~ ~GLSHLD~ ~GMSHLD~ ~GQUIVER0~ ~GSSHLD~ ~iamul19~ ~iamul20~ ~iamul21~ ~iamul22~ ~iamul23~ ~iamul24~ ~iamul25~ ~iamul26~ ~iamul27~ ~iamul28~ ~iarow01~ ~iarow15~ ~ibelt10~ ~IBLUN13B~ ~IBLUN16~ ~iblun30b~ ~ibolt09~ ~ibook09~ ~ibook768~ ~iboot07~ ~iboot12~ ~ibrac13~ ~ibrac14~ ~ibrac15~ ~ibrac21~ ~ibrac22~ ~ibrac23~ ~ibrac24~ ~ibrac25~ ~ibrac26~ ~ichan01~ ~ichan02~ ~ichan03~ ~ichan06~ ~ichan07~ ~ichan08~ ~ichan09~ ~ichan10~ ~ichan11~ ~ichan12~ ~ichan13~ ~ichan14~ ~ichan15~ ~ichan16~ ~ichan17~ ~ichan18~ ~ichan19~ ~ichan20~ ~ichan21~ ~iclck08~ ~iclck31~ ~idagg23~ ~IDART01~ ~idart08~ ~idchan01~ ~idchan02~ ~idplat01~ ~ihalb04~ ~ihalb05~ ~ihalb06~ ~ihalb07~ ~ihalb08~ ~ihalb09~ ~ihalb09a~ ~ihalb09b~ ~ihalb10~ ~ihalb11~ ~ihalb12~ ~ihelm17~ ~ihelm21~ ~ihelm31~ ~ihelm32~ ~imisc4y~ ~imisc5e~ ~imisc5w~ ~imisc5x~ ~imisc7r~ ~imisc7y~ ~imisca9~ ~imiscaa~ ~imiscad~ ~imiscae~ ~inpchan~ ~inpplat~ ~iplat02~ ~iplat10~ ~iplat11~ ~iplat12~ ~iplat13~ ~iplat14~ ~iplat15~ ~iplat16~ ~iplat17~ ~iplat18~ ~iplat20~ ~iplat21~ ~iplat22~ ~ipotn54~ ~iring39~ ~iring43~ ~iring44~ ~iring45~ ~ishld04~ ~ishld14~ ~ishld17~ ~ishld21~ ~ishld22~ ~ishld23~ ~ishld25~ ~ishld27~ ~ishld28~ ~ishld29~ ~ishld32~ ~ishldb01~ ~ishldb02~ ~ishldb03~ ~ishldb04~ ~ishldl01~ ~ishldl02~ ~ishldl03~ ~ishldl04~ ~ishldl05~ ~ishldl06~ ~ishldm01~ ~ishldm02~ ~ishldm03~ ~ishldm04~ ~ishldm05~ ~ishldm06~ ~ishldm07~ ~ishldm08~ ~ishldm09~ ~ishlds01~ ~ishlds02~ ~ishlds03~ ~ishlds04~ ~ishlds05~ ~isper11~ ~isper12~ ~istaf11~ ~ISTAF12~ ~istaf19~ ~ISTAF20~ ~istaf21~ ~istaf22~ ~istaf23~ ~istaf24~ ~isw1h02~ ~isw1h06~ ~ISW1H22~ ~isw1h42~ ~ISW1H51~ ~isw2h10~ ~ISW2H13~ ~ISW2H15~ ~isw2h21~ ~iwand12~ ~iwand13~ ~iwand14~ ~iwand18~ ~iwand19~ ~ILEAT20~ ~1shldaj~ ~1cband01~ ~1cband03~ ~1cband04~ ~1cband05~ ~1cband06~ ~1chelm11~ ~1chelm17~ ~1chelm18~ ~1chelm20~ ~1chelm21~ ~1chelmx2~ ~1chelmx3~ ~1chelmx4~ ~1chelmx6~ ~1chelmx9~ ~1cshldaj~ ~1cshldb1~ ~1cshldl1~ ~1cshldl2~ ~1cshldl3~ ~1cshldl4~ ~1cshldm1~ ~1cshldm2~ ~1cshldm3~ ~1cshldm4~ ~cshld30~ ~cshldm0~ ~chelm17~ ~cplat08~ BEGIN
-+ACTION_FOR_EACH resource IN ~1amul07B~ ~1amul07C~ ~1band01~ ~1band02~ ~1band03~ ~1band04~ ~1band05~ ~1band06~ ~1BOLTS01~ ~1BOLTS02~ ~1chan01B~ ~1chan02B~ ~1chan03B~ ~1chan04B~ ~1clck07B~ ~1clck27B~ ~1CSTAFM~ ~1GLEAT01~ ~1GSTAFGS~ ~1helm00~ ~1helm01~ ~1helm02~ ~1helm03~ ~1helm04~ ~1helm05~ ~1helm06~ ~1helm07~ ~1helm08~ ~1helm09~ ~1helm10~ ~1helm11~ ~1helm12~ ~1helm13~ ~1helm14~ ~1helm15~ ~1helm16~ ~1helm17~ ~1helm18~ ~1helm19~ ~1helm20~ ~1helm21~ ~1helm22~ ~1helm23~ ~1helm24~ ~1helm25~ ~1helm26~ ~1leat02~ ~1LEAT05~ ~1LEAT06~ ~1LEAT07~ ~1LEAT08~ ~1LEAT10~ ~1PLAT02~ ~1PLAT04~ ~1PLAT05~ ~1plat13~ ~1plat18B~ ~1plat23B~ ~1QBULL02~ ~1QBULL03~ ~1QUIV01~ ~1QUIV02~ ~1shld172~ ~1shldl01~ ~1shldl02~ ~1shldl03~ ~1shldl04~ ~1shldl05~ ~1shldm01~ ~1shldm02~ ~1shldm03~ ~1shldm04~ ~1swh00~ ~GBOW02~ ~GBSHLD~ ~GLSHLD~ ~GMSHLD~ ~GQUIVER0~ ~GSSHLD~ ~iamul19~ ~iamul20~ ~iamul21~ ~iamul22~ ~iamul23~ ~iamul24~ ~iamul25~ ~iamul26~ ~iamul27~ ~iamul28~ ~iarow01~ ~iarow15~ ~ibelt10~ ~IBLUN13B~ ~iblun30b~ ~ibolt09~ ~ibook09~ ~ibook768~ ~iboot07~ ~iboot12~ ~ibrac13~ ~ibrac14~ ~ibrac15~ ~ibrac21~ ~ibrac22~ ~ibrac23~ ~ibrac24~ ~ibrac25~ ~ibrac26~ ~ichan01~ ~ichan02~ ~ichan03~ ~ichan06~ ~ichan07~ ~ichan08~ ~ichan09~ ~ichan10~ ~ichan11~ ~ichan12~ ~ichan13~ ~ichan14~ ~ichan15~ ~ichan16~ ~ichan17~ ~ichan18~ ~ichan19~ ~ichan20~ ~ichan21~ ~iclck08~ ~iclck31~ ~idagg23~ ~IDART01~ ~idart08~ ~idchan01~ ~idchan02~ ~idplat01~ ~ihalb04~ ~ihalb05~ ~ihalb06~ ~ihalb07~ ~ihalb08~ ~ihalb09~ ~ihalb09a~ ~ihalb09b~ ~ihalb10~ ~ihalb11~ ~ihalb12~ ~ihelm17~ ~ihelm21~ ~ihelm31~ ~ihelm32~ ~imisc4y~ ~imisc5e~ ~imisc5w~ ~imisc5x~ ~imisc7r~ ~imisc7y~ ~imisca9~ ~imiscaa~ ~imiscad~ ~imiscae~ ~inpchan~ ~inpplat~ ~iplat02~ ~iplat10~ ~iplat11~ ~iplat12~ ~iplat13~ ~iplat14~ ~iplat15~ ~iplat16~ ~iplat17~ ~iplat18~ ~iplat20~ ~iplat21~ ~iplat22~ ~ipotn54~ ~iring39~ ~iring43~ ~iring44~ ~iring45~ ~ishld04~ ~ishld14~ ~ishld17~ ~ishld21~ ~ishld22~ ~ishld23~ ~ishld25~ ~ishld27~ ~ishld28~ ~ishld29~ ~ishld32~ ~ishldb01~ ~ishldb02~ ~ishldb03~ ~ishldb04~ ~ishldl01~ ~ishldl02~ ~ishldl03~ ~ishldl04~ ~ishldl05~ ~ishldl06~ ~ishldm01~ ~ishldm02~ ~ishldm03~ ~ishldm04~ ~ishldm05~ ~ishldm06~ ~ishldm07~ ~ishldm08~ ~ishldm09~ ~ishlds01~ ~ishlds02~ ~ishlds03~ ~ishlds04~ ~ishlds05~ ~isper11~ ~isper12~ ~istaf11~ ~ISTAF12~ ~istaf19~ ~ISTAF20~ ~istaf21~ ~istaf22~ ~istaf23~ ~istaf24~ ~isw1h02~ ~isw1h06~ ~ISW1H22~ ~isw1h42~ ~ISW1H51~ ~isw2h10~ ~ISW2H13~ ~ISW2H15~ ~isw2h21~ ~iwand12~ ~iwand13~ ~iwand14~ ~iwand18~ ~iwand19~ ~ILEAT20~ ~1shldaj~ ~1cband01~ ~1cband03~ ~1cband04~ ~1cband05~ ~1cband06~ ~1chelm11~ ~1chelm17~ ~1chelm18~ ~1chelm20~ ~1chelm21~ ~1chelmx2~ ~1chelmx3~ ~1chelmx4~ ~1chelmx6~ ~1chelmx9~ ~1cshldaj~ ~1cshldb1~ ~1cshldl1~ ~1cshldl2~ ~1cshldl3~ ~1cshldl4~ ~1cshldm1~ ~1cshldm2~ ~1cshldm3~ ~1cshldm4~ ~cshld30~ ~cshldm0~ ~chelm17~ ~cplat08~ BEGIN
- COPY		~1pp/item/1ppv4_update/bam/%resource%.bam~ ~override~
- END
- 
-+COPY ~1pp/item/1ppv4_update/bam/IBLUN16.bam~ ~override/waflail.bam~
-+
- ACTION_FOR_EACH resource IN ~1CHELM01~ ~1CHELM02~ ~1CHELM03~ ~1CHELM04~ ~1CHELM05~ ~1CHELM06~ ~1CHELM07~ BEGIN
- COPY		~1pp/additions/carried_1pp/%resource%.bam~ ~override~
- END
-@@ -1351,23 +1353,26 @@
- 	SET location = spink		// location
- 	LAUNCH_PATCH_MACRO ~colour~
- END
--COPY_EXISTING ~shld24.itm~ ~override~
-+COPY_EXISTING ~shld24.itm~ ~override~ //Fix tower shield animation (note: having to use its original small shield animation here for the time being, because there isn't really a suitable buckler icon for it - still erroneous, but nearly as bad as the tower shield!)
- PATCH_IF (SOURCE_SIZE > 0x71) THEN BEGIN // protects against invalid files
--    WRITE_ASCII 0x22 ~C6~
-+    WRITE_ASCII 0x22 ~C0~
-     WRITE_LONG  0x3E 0
--    WRITE_ASCII 0x3A ~1SHLDL05~
-+    WRITE_ASCII 0x3A ~ISHLD24~
-     WRITE_LONG  0x48 0
--    WRITE_ASCII 0x44 ~GLSHLD~
-+    WRITE_ASCII 0x44 ~GSSHLD~
-     WRITE_LONG  0x5C 0
--    WRITE_ASCII 0x58 ~1CSHLDL1~
-+    WRITE_ASCII 0x58 ~CSHLD24~
- 	LAUNCH_PATCH_MACRO ~clear~
--	SET gradient = 250		// colour index
--	SET location = sgrey		// location
-+	SET gradient = 43		// colour index
-+	SET location = sred		// location
- 	LAUNCH_PATCH_MACRO ~colour~
--	SET gradient = 112		// colour index
--	SET location = steal		// location
-+	SET gradient = 43		// colour index
-+	SET location = sblue		// location
- 	LAUNCH_PATCH_MACRO ~colour~
--	SET gradient = 112		// colour index
-+	SET gradient = 43		// colour index
-+	SET location = sgrey		// location
-+	LAUNCH_PATCH_MACRO ~colour~
-+	SET gradient = 65		// colour index
- 	SET location = spink		// location
- 	LAUNCH_PATCH_MACRO ~colour~
+--- C:\Users\Bartimaeus\Desktop\200_1ppv2_cut.tph	2011-05-01 19:02:59.250000000 -0500
++++ E:\Backups\Games\Baldur's Gate II\Tools\Directory Override\1pp\install\200_1ppv2_cut.tph	2018-02-08 13:03:42.138617600 -0600
+@@ -29,7 +29,7 @@
+   BUT_ONLY_IF_IT_CHANGES
    END
-@@ -2766,7 +2771,7 @@
- STATISTICS:
  
- Armor Class Bonus: 1
--Special:  +1 vs. Missile Weapons
-+Special: +1 vs. Missile Weapons
- Weight: 10
- Requires: 10 Strength
- Not Usable By:
-@@ -3995,7 +4000,7 @@
-   ACTION_IF (FILE_EXISTS_IN_GAME ~helm04.itm~) THEN BEGIN
- COPY_EXISTING ~helm04.itm~ ~override~
- PATCH_IF (SOURCE_SIZE > 0x71) THEN BEGIN // protects against invalid files
--    WRITE_ASCII 0x22 ~J1~
-+    WRITE_ASCII 0x22 ~J6~
-     WRITE_LONG  0x3E 0
-     WRITE_ASCII 0x3A ~1HELM21~
-     WRITE_LONG  0x5C 0
-@@ -4235,19 +4240,19 @@
-   ACTION_IF (FILE_EXISTS_IN_GAME ~helm13.itm~) THEN BEGIN
- COPY_EXISTING ~helm13.itm~ ~override~
- PATCH_IF (SOURCE_SIZE > 0x71) THEN BEGIN // protects against invalid files
--    WRITE_ASCII 0x22 ~J5~
-+    WRITE_ASCII 0x22 ~J4~
-     WRITE_LONG  0x3E 0
--    WRITE_ASCII 0x3A ~1HELM12~
-+    WRITE_ASCII 0x3A ~1HELM10~
-     WRITE_LONG  0x5C 0
-     WRITE_ASCII 0x58 ~CHELM05~
- 	LAUNCH_PATCH_MACRO ~clear~
--	SET gradient = 210		// colour index
-+	SET gradient = 248		// colour index
- 	SET location = hgrey		// location
- 	LAUNCH_PATCH_MACRO ~colour~
- 	SET gradient = 102	// colour index
- 	SET location = hblue		// location
- 	LAUNCH_PATCH_MACRO ~colour~
--	SET gradient = 248	// colour index
-+	SET gradient = 210	// colour index
- 	SET location = hred		// location
- 	LAUNCH_PATCH_MACRO ~colour~
- 	PATCH_IF (%pcolour% = 2 || %pcolour% = 3) THEN BEGIN
-@@ -4295,11 +4300,11 @@
-   ACTION_IF (FILE_EXISTS_IN_GAME ~helm15.itm~) THEN BEGIN
- COPY_EXISTING ~helm15.itm~ ~override~
- PATCH_IF (SOURCE_SIZE > 0x71) THEN BEGIN // protects against invalid files
--    WRITE_ASCII 0x22 ~J0~
-+    WRITE_ASCII 0x22 ~J3~
-     WRITE_LONG  0x3E 0
--    WRITE_ASCII 0x3A ~1HELM15~
-+    WRITE_ASCII 0x3A ~1HELM23~
-     WRITE_LONG  0x5C 0
--    WRITE_ASCII 0x58 ~1CHELM11~
-+    WRITE_ASCII 0x58 ~CHELM04~
- 	LAUNCH_PATCH_MACRO ~clear~
- 	SET gradient = 232		// colour index
- 	SET location = hgrey		// location
-@@ -4491,7 +4496,7 @@
-   END
-   
-   ACTION_IF (FILE_EXISTS_IN_GAME ~helm33.itm~) THEN BEGIN
--COPY_EXISTING ~helm32.itm~ ~override~
-+COPY_EXISTING ~helm33.itm~ ~override~ //Gold Horned Helm bug fix
- PATCH_IF (SOURCE_SIZE > 0x71) THEN BEGIN // protects against invalid files
-     WRITE_ASCII 0x22 ~J3~
- 	LAUNCH_PATCH_MACRO ~clear~
-@@ -4519,7 +4524,7 @@
-  ACTION_IF (FILE_EXISTS_IN_GAME ~compon05.itm~) THEN BEGIN
+-    ACTION_IF (FILE_EXISTS_IN_GAME ~compon05.itm~) THEN BEGIN
++/*    ACTION_IF (FILE_EXISTS_IN_GAME ~compon05.itm~) THEN BEGIN //Roranach's Horn getting weird IWD graphic
  COPY_EXISTING ~compon05.itm~ ~override~
- PATCH_IF (SOURCE_SIZE > 0x71) THEN BEGIN // protects against invalid files
--    WRITE_ASCII 0x22 ~J9~
-+    WRITE_ASCII 0x22 ~J3~ //J9 is for the IWD-style icon
- 	LAUNCH_PATCH_MACRO ~clear~
- 	SET gradient = 225		// colour index
- 	SET location = hgrey		// location
-@@ -6418,7 +6423,7 @@
-   END
-   
-   ACTION_IF (FILE_EXISTS_IN_GAME ~helm33.itm~) THEN BEGIN
--COPY_EXISTING ~helm32.itm~ ~override~
-+COPY_EXISTING ~helm33.itm~ ~override~ //Gold Horned Helm bug fix
- PATCH_IF (SOURCE_SIZE > 0x71) THEN BEGIN // protects against invalid files
-     WRITE_ASCII 0x22 ~J3~
- 	LAUNCH_PATCH_MACRO ~clear~
-@@ -6503,7 +6508,7 @@
-   
-   
-   ACTION_IF (FILE_EXISTS_IN_GAME ~amul02.itm~) THEN BEGIN
--COPY_EXISTING ~amul02.itm~ ~override/band02.itm~
-+COPY_EXISTING ~amul02.itm~ ~override/xoband02.itm~
- PATCH_IF (SOURCE_SIZE > 0x71) THEN BEGIN // protects against invalid files
-     WRITE_ASCII 0x22 ~JB~
-     WRITE_LONG  0x3E 0
-@@ -6587,7 +6592,7 @@
-   END
-   
-   ACTION_IF (FILE_EXISTS_IN_GAME ~amul02.itm~) THEN BEGIN
--COPY_EXISTING ~amul02.itm~ ~override/band01.itm~
-+COPY_EXISTING ~amul02.itm~ ~override/xoband01.itm~
- PATCH_IF (SOURCE_SIZE > 0x71) THEN BEGIN // protects against invalid files
-     WRITE_ASCII 0x22 ~JB~
-     WRITE_LONG  0x3E 0
-@@ -6609,7 +6614,7 @@
-   
-   
-   ACTION_IF (FILE_EXISTS_IN_GAME ~amul02.itm~) THEN BEGIN
--COPY_EXISTING ~amul02.itm~ ~override/band03.itm~
-+COPY_EXISTING ~amul02.itm~ ~override/xoband03.itm~
- PATCH_IF (SOURCE_SIZE > 0x71) THEN BEGIN // protects against invalid files
-     WRITE_ASCII 0x22 ~JB~
-     WRITE_LONG  0x3E 0
-@@ -6712,7 +6717,7 @@
-   END
-   
-   ACTION_IF (FILE_EXISTS_IN_GAME ~amul02.itm~) THEN BEGIN
--COPY_EXISTING ~amul02.itm~ ~override/band04.itm~
-+COPY_EXISTING ~amul02.itm~ ~override/xoband04.itm~
- PATCH_IF (SOURCE_SIZE > 0x71) THEN BEGIN // protects against invalid files
-     WRITE_ASCII 0x22 ~JB~
-     WRITE_LONG  0x3E 0
-@@ -7433,8 +7438,25 @@
-   BUT_ONLY_IF_IT_CHANGES
-   END
-   
--  ACTION_IF (FILE_EXISTS_IN_GAME ~ax1h06.itm~) THEN BEGIN
--COPY_EXISTING ~ax1h06.itm~ ~override~
-+  ACTION_IF (FILE_EXISTS_IN_GAME ~ax1h05a.itm~) THEN BEGIN //IR compatibility
-+COPY_EXISTING ~ax1h05a.itm~ ~override~
-+PATCH_IF (SOURCE_SIZE > 0x71) THEN BEGIN // protects against invalid files
-+    LAUNCH_PATCH_MACRO ~clear~
-+	SET gradient = 249	// colour index
-+	SET location = wgrey		// location
-+	LAUNCH_PATCH_MACRO ~colour~
-+	SET gradient = 91	// colour index
-+	SET location = wred		// location
-+	LAUNCH_PATCH_MACRO ~colour~
-+	SET gradient = 6	// colour index
-+	SET location = wblue		// location
-+	LAUNCH_PATCH_MACRO ~colour~
-+    END
-+  BUT_ONLY_IF_IT_CHANGES
-+  END
-+  
-+  ACTION_IF (FILE_EXISTS_IN_GAME ~ax1h05b.itm~) THEN BEGIN //IR compatibility
-+COPY_EXISTING ~ax1h05b.itm~ ~override~
- PATCH_IF (SOURCE_SIZE > 0x71) THEN BEGIN // protects against invalid files
-     LAUNCH_PATCH_MACRO ~clear~
- 	SET gradient = 249	// colour index
-@@ -7450,6 +7472,57 @@
-   BUT_ONLY_IF_IT_CHANGES
-   END
-   
-+  ACTION_IF (FILE_EXISTS_IN_GAME ~ax1h06.itm~) THEN BEGIN
-+COPY_EXISTING ~ax1h06.itm~ ~override~
-+PATCH_IF (SOURCE_SIZE > 0x71) THEN BEGIN // protects against invalid files
-+    LAUNCH_PATCH_MACRO ~clear~
-+	SET gradient = 232	// colour index
-+	SET location = wgrey		// location
-+	LAUNCH_PATCH_MACRO ~colour~
-+	SET gradient = 207	// colour index
-+	SET location = wred		// location
-+	LAUNCH_PATCH_MACRO ~colour~
-+	SET gradient = 202	// colour index
-+	SET location = wblue		// location
-+	LAUNCH_PATCH_MACRO ~colour~
-+    END
-+  BUT_ONLY_IF_IT_CHANGES
-+  END
-+  
-+  ACTION_IF (FILE_EXISTS_IN_GAME ~ax1h06a.itm~) THEN BEGIN //IR compatibility
-+COPY_EXISTING ~ax1h06a.itm~ ~override~
-+PATCH_IF (SOURCE_SIZE > 0x71) THEN BEGIN // protects against invalid files
-+    LAUNCH_PATCH_MACRO ~clear~
-+	SET gradient = 232	// colour index
-+	SET location = wgrey		// location
-+	LAUNCH_PATCH_MACRO ~colour~
-+	SET gradient = 207	// colour index
-+	SET location = wred		// location
-+	LAUNCH_PATCH_MACRO ~colour~
-+	SET gradient = 202	// colour index
-+	SET location = wblue		// location
-+	LAUNCH_PATCH_MACRO ~colour~
-+    END
-+  BUT_ONLY_IF_IT_CHANGES
-+  END
-+  
-+  ACTION_IF (FILE_EXISTS_IN_GAME ~ax1h06b.itm~) THEN BEGIN //IR compatibility
-+COPY_EXISTING ~ax1h06b.itm~ ~override~
-+PATCH_IF (SOURCE_SIZE > 0x71) THEN BEGIN // protects against invalid files
-+    LAUNCH_PATCH_MACRO ~clear~
-+	SET gradient = 232	// colour index
-+	SET location = wgrey		// location
-+	LAUNCH_PATCH_MACRO ~colour~
-+	SET gradient = 207	// colour index
-+	SET location = wred		// location
-+	LAUNCH_PATCH_MACRO ~colour~
-+	SET gradient = 202	// colour index
-+	SET location = wblue		// location
-+	LAUNCH_PATCH_MACRO ~colour~
-+    END
-+  BUT_ONLY_IF_IT_CHANGES
-+  END
-+  
-   ACTION_IF (FILE_EXISTS_IN_GAME ~ax1h07.itm~) THEN BEGIN
- COPY_EXISTING ~ax1h07.itm~ ~override~
- PATCH_IF (SOURCE_SIZE > 0x71) THEN BEGIN // protects against invalid files
-@@ -7484,6 +7557,40 @@
-   BUT_ONLY_IF_IT_CHANGES
-   END
-   
-+  ACTION_IF (FILE_EXISTS_IN_GAME ~ax1h08a.itm~) THEN BEGIN //IR compatibility
-+COPY_EXISTING ~ax1h08a.itm~ ~override~
-+PATCH_IF (SOURCE_SIZE > 0x71) THEN BEGIN // protects against invalid files
-+    LAUNCH_PATCH_MACRO ~clear~
-+	SET gradient = 232	// colour index
-+	SET location = wgrey		// location
-+	LAUNCH_PATCH_MACRO ~colour~
-+	SET gradient = 99	// colour index
-+	SET location = wred		// location
-+	LAUNCH_PATCH_MACRO ~colour~
-+	SET gradient = 202	// colour index
-+	SET location = wblue		// location
-+	LAUNCH_PATCH_MACRO ~colour~
-+    END
-+  BUT_ONLY_IF_IT_CHANGES
-+  END
-+  
-+  ACTION_IF (FILE_EXISTS_IN_GAME ~ax1h08b.itm~) THEN BEGIN  //IR compatibility
-+COPY_EXISTING ~ax1h08b.itm~ ~override~
-+PATCH_IF (SOURCE_SIZE > 0x71) THEN BEGIN // protects against invalid files
-+    LAUNCH_PATCH_MACRO ~clear~
-+	SET gradient = 232	// colour index
-+	SET location = wgrey		// location
-+	LAUNCH_PATCH_MACRO ~colour~
-+	SET gradient = 99	// colour index
-+	SET location = wred		// location
-+	LAUNCH_PATCH_MACRO ~colour~
-+	SET gradient = 202	// colour index
-+	SET location = wblue		// location
-+	LAUNCH_PATCH_MACRO ~colour~
-+    END
-+  BUT_ONLY_IF_IT_CHANGES
-+  END
-+  
-   ACTION_IF (FILE_EXISTS_IN_GAME ~ax1h09.itm~) THEN BEGIN
- COPY_EXISTING ~ax1h09.itm~ ~override~
- PATCH_IF (SOURCE_SIZE > 0x71) THEN BEGIN // protects against invalid files
-@@ -7500,6 +7607,40 @@
+   PATCH_IF (SOURCE_SIZE > 0x71) THEN BEGIN // protects against invalid files
+     WRITE_ASCII 0x22 ~H0~
+@@ -50,10 +50,10 @@
      END
-   BUT_ONLY_IF_IT_CHANGES
    END
-+  
-+  ACTION_IF (FILE_EXISTS_IN_GAME ~ax1h09a.itm~) THEN BEGIN //IR compatibility
-+COPY_EXISTING ~ax1h09a.itm~ ~override~
-+PATCH_IF (SOURCE_SIZE > 0x71) THEN BEGIN // protects against invalid files
-+    LAUNCH_PATCH_MACRO ~clear~
-+	SET gradient = 245	// colour index
-+	SET location = wgrey		// location
-+	LAUNCH_PATCH_MACRO ~colour~
-+	SET gradient = 229	// colour index
-+	SET location = wred		// location
-+	LAUNCH_PATCH_MACRO ~colour~
-+	SET gradient = 231	// colour index
-+	SET location = wblue		// location
-+	LAUNCH_PATCH_MACRO ~colour~
-+    END
-+  BUT_ONLY_IF_IT_CHANGES
-+  END
-+  
-+  ACTION_IF (FILE_EXISTS_IN_GAME ~ax1h09b.itm~) THEN BEGIN //IR compatibility
-+COPY_EXISTING ~ax1h09b.itm~ ~override~
-+PATCH_IF (SOURCE_SIZE > 0x71) THEN BEGIN // protects against invalid files
-+    LAUNCH_PATCH_MACRO ~clear~
-+	SET gradient = 245	// colour index
-+	SET location = wgrey		// location
-+	LAUNCH_PATCH_MACRO ~colour~
-+	SET gradient = 229	// colour index
-+	SET location = wred		// location
-+	LAUNCH_PATCH_MACRO ~colour~
-+	SET gradient = 231	// colour index
-+	SET location = wblue		// location
-+	LAUNCH_PATCH_MACRO ~colour~
-+    END
-+  BUT_ONLY_IF_IT_CHANGES
-+  END
- 
-   ACTION_IF (FILE_EXISTS_IN_GAME ~ax1h10.itm~) THEN BEGIN
- COPY_EXISTING ~ax1h10.itm~ ~override~
-@@ -7536,6 +7677,76 @@
    BUT_ONLY_IF_IT_CHANGES
-   END
+-END
++END*/
    
-+  ACTION_IF (FILE_EXISTS_IN_GAME ~ax1h10a.itm~) THEN BEGIN //IR compatibility
-+COPY_EXISTING ~ax1h10a.itm~ ~override~
-+PATCH_IF (SOURCE_SIZE > 0x71) THEN BEGIN // protects against invalid files
-+    LAUNCH_PATCH_MACRO ~clear~
-+	SET setr = 255
-+	SET setg = 76
-+	SET setb = 106
-+	SET speed = 0x14
-+	SET location = wgrey		// location
-+	LAUNCH_PATCH_MACRO ~pulse~
-+	SET setr = 122
-+	SET setg = 35
-+	SET setb = 50
-+	SET speed = 0x14
-+	SET location = wblue		// location
-+	LAUNCH_PATCH_MACRO ~pulse~
-+	SET setr = 0
-+	SET setg = 0
-+	SET setb = 0
-+	SET speed = 0x14
-+	SET location = wred		// location
-+	LAUNCH_PATCH_MACRO ~pulse~
-+	SET gradient = 247	// colour index
-+	SET location = wgrey		// location
-+	LAUNCH_PATCH_MACRO ~colour~
-+	SET gradient = 210	// colour index
-+	SET location = wred		// location
-+	LAUNCH_PATCH_MACRO ~colour~
-+	SET gradient = 227	// colour index
-+	SET location = wblue		// location
-+	LAUNCH_PATCH_MACRO ~colour~
-+    END
-+  BUT_ONLY_IF_IT_CHANGES
-+  END
-+  
-+  ACTION_IF (FILE_EXISTS_IN_GAME ~ax1h10b.itm~) THEN BEGIN //IR compatibility
-+COPY_EXISTING ~ax1h10b.itm~ ~override~
-+PATCH_IF (SOURCE_SIZE > 0x71) THEN BEGIN // protects against invalid files
-+    LAUNCH_PATCH_MACRO ~clear~
-+	SET setr = 255
-+	SET setg = 76
-+	SET setb = 106
-+	SET speed = 0x14
-+	SET location = wgrey		// location
-+	LAUNCH_PATCH_MACRO ~pulse~
-+	SET setr = 122
-+	SET setg = 35
-+	SET setb = 50
-+	SET speed = 0x14
-+	SET location = wblue		// location
-+	LAUNCH_PATCH_MACRO ~pulse~
-+	SET setr = 0
-+	SET setg = 0
-+	SET setb = 0
-+	SET speed = 0x14
-+	SET location = wred		// location
-+	LAUNCH_PATCH_MACRO ~pulse~
-+	SET gradient = 247	// colour index
-+	SET location = wgrey		// location
-+	LAUNCH_PATCH_MACRO ~colour~
-+	SET gradient = 210	// colour index
-+	SET location = wred		// location
-+	LAUNCH_PATCH_MACRO ~colour~
-+	SET gradient = 227	// colour index
-+	SET location = wblue		// location
-+	LAUNCH_PATCH_MACRO ~colour~
-+    END
-+  BUT_ONLY_IF_IT_CHANGES
-+  END
-+  
-   ACTION_IF (FILE_EXISTS_IN_GAME ~ax1h11.itm~) THEN BEGIN
- COPY_EXISTING ~ax1h11.itm~ ~override~
- PATCH_IF (SOURCE_SIZE > 0x71) THEN BEGIN // protects against invalid files
-@@ -7686,6 +7897,40 @@
-   BUT_ONLY_IF_IT_CHANGES
-   END
    
-+  ACTION_IF (FILE_EXISTS_IN_GAME ~ax1h16a.itm~) THEN BEGIN //IR compatibility
-+COPY_EXISTING ~ax1h16a.itm~ ~override~
-+PATCH_IF (SOURCE_SIZE > 0x71) THEN BEGIN // protects against invalid files
-+    LAUNCH_PATCH_MACRO ~clear~
-+	SET gradient = 225	// colour index
-+	SET location = wgrey		// location
-+	LAUNCH_PATCH_MACRO ~colour~
-+	SET gradient = 51	// colour index
-+	SET location = wred		// location
-+	LAUNCH_PATCH_MACRO ~colour~
-+	SET gradient = 254	// colour index
-+	SET location = wblue		// location
-+	LAUNCH_PATCH_MACRO ~colour~
-+    END
-+  BUT_ONLY_IF_IT_CHANGES
-+  END
-+  
-+  ACTION_IF (FILE_EXISTS_IN_GAME ~ax1h16b.itm~) THEN BEGIN //IR compatibility
-+COPY_EXISTING ~ax1h16b.itm~ ~override~
-+PATCH_IF (SOURCE_SIZE > 0x71) THEN BEGIN // protects against invalid files
-+    LAUNCH_PATCH_MACRO ~clear~
-+	SET gradient = 225	// colour index
-+	SET location = wgrey		// location
-+	LAUNCH_PATCH_MACRO ~colour~
-+	SET gradient = 51	// colour index
-+	SET location = wred		// location
-+	LAUNCH_PATCH_MACRO ~colour~
-+	SET gradient = 254	// colour index
-+	SET location = wblue		// location
-+	LAUNCH_PATCH_MACRO ~colour~
-+    END
-+  BUT_ONLY_IF_IT_CHANGES
-+  END
-+  
-   ACTION_IF (FILE_EXISTS_IN_GAME ~ax1h17.itm~) THEN BEGIN
- COPY_EXISTING ~ax1h17.itm~ ~override~
- PATCH_IF (SOURCE_SIZE > 0x71) THEN BEGIN // protects against invalid files
-@@ -7881,91 +8126,204 @@
- COPY_EXISTING ~dagg09.itm~ ~override~
- PATCH_IF (SOURCE_SIZE > 0x71) THEN BEGIN // protects against invalid files
-     LAUNCH_PATCH_MACRO ~clear~
--	SET gradient = 228	// colour index
-+	SET gradient = 228	// colour index
-+	SET location = wgrey		// location
-+	LAUNCH_PATCH_MACRO ~colour~
-+	SET gradient = 248	// colour index
-+	SET location = wred		// location
-+	LAUNCH_PATCH_MACRO ~colour~
-+	SET gradient = 27	// colour index
-+	SET location = wblue		// location
-+	LAUNCH_PATCH_MACRO ~colour~
-+    END
-+  BUT_ONLY_IF_IT_CHANGES
-+  END
-+  
-+	ACTION_IF (FILE_EXISTS_IN_GAME ~dagg09a.itm~) THEN BEGIN //IR compatibility
-+COPY_EXISTING ~dagg09a.itm~ ~override~
-+PATCH_IF (SOURCE_SIZE > 0x71) THEN BEGIN // protects against invalid files
-+    LAUNCH_PATCH_MACRO ~clear~
-+	SET gradient = 228	// colour index
-+	SET location = wgrey		// location
-+	LAUNCH_PATCH_MACRO ~colour~
-+	SET gradient = 248	// colour index
-+	SET location = wred		// location
-+	LAUNCH_PATCH_MACRO ~colour~
-+	SET gradient = 27	// colour index
-+	SET location = wblue		// location
-+	LAUNCH_PATCH_MACRO ~colour~
-+    END
-+  BUT_ONLY_IF_IT_CHANGES
-+  END
-+  
-+	ACTION_IF (FILE_EXISTS_IN_GAME ~dagg09b.itm~) THEN BEGIN //IR compatibility
-+COPY_EXISTING ~dagg09b.itm~ ~override~
-+PATCH_IF (SOURCE_SIZE > 0x71) THEN BEGIN // protects against invalid files
-+    LAUNCH_PATCH_MACRO ~clear~
-+	SET gradient = 228	// colour index
-+	SET location = wgrey		// location
-+	LAUNCH_PATCH_MACRO ~colour~
-+	SET gradient = 248	// colour index
-+	SET location = wred		// location
-+	LAUNCH_PATCH_MACRO ~colour~
-+	SET gradient = 27	// colour index
-+	SET location = wblue		// location
-+	LAUNCH_PATCH_MACRO ~colour~
-+    END
-+  BUT_ONLY_IF_IT_CHANGES
-+  END
-+  
-+  ACTION_IF (FILE_EXISTS_IN_GAME ~_dagg09.itm~) THEN BEGIN
-+COPY_EXISTING ~_dagg09.itm~ ~override~
-+PATCH_IF (SOURCE_SIZE > 0x71) THEN BEGIN // protects against invalid files
-+    LAUNCH_PATCH_MACRO ~clear~
-+	SET gradient = 228	// colour index
-+	SET location = wgrey		// location
-+	LAUNCH_PATCH_MACRO ~colour~
-+	SET gradient = 248	// colour index
-+	SET location = wred		// location
-+	LAUNCH_PATCH_MACRO ~colour~
-+	SET gradient = 27	// colour index
-+	SET location = wblue		// location
-+	LAUNCH_PATCH_MACRO ~colour~
-+    END
-+  BUT_ONLY_IF_IT_CHANGES
-+  END
-+  
-+	ACTION_IF (FILE_EXISTS_IN_GAME ~dagg10.itm~) THEN BEGIN
-+COPY_EXISTING ~dagg10.itm~ ~override~
-+PATCH_IF (SOURCE_SIZE > 0x71) THEN BEGIN // protects against invalid files
-+    LAUNCH_PATCH_MACRO ~clear~
-+	SET gradient = 236	// colour index
-+	SET location = wgrey		// location
-+	LAUNCH_PATCH_MACRO ~colour~
-+	SET gradient = 227	// colour index
-+	SET location = wred		// location
-+	LAUNCH_PATCH_MACRO ~colour~
-+	SET gradient = 5	// colour index
-+	SET location = wblue		// location
-+	LAUNCH_PATCH_MACRO ~colour~
-+    END
-+  BUT_ONLY_IF_IT_CHANGES
-+  END
-+  
-+  ACTION_IF (FILE_EXISTS_IN_GAME ~_dagg10.itm~) THEN BEGIN
-+COPY_EXISTING ~_dagg10.itm~ ~override~
-+PATCH_IF (SOURCE_SIZE > 0x71) THEN BEGIN // protects against invalid files
-+    LAUNCH_PATCH_MACRO ~clear~
-+	SET gradient = 236	// colour index
-+	SET location = wgrey		// location
-+	LAUNCH_PATCH_MACRO ~colour~
-+	SET gradient = 227	// colour index
-+	SET location = wred		// location
-+	LAUNCH_PATCH_MACRO ~colour~
-+	SET gradient = 5	// colour index
-+	SET location = wblue		// location
-+	LAUNCH_PATCH_MACRO ~colour~
-+    END
-+  BUT_ONLY_IF_IT_CHANGES
-+  END
-+  
-+  
-+	ACTION_IF (FILE_EXISTS_IN_GAME ~dagg11.itm~) THEN BEGIN
-+COPY_EXISTING ~dagg11.itm~ ~override~
-+PATCH_IF (SOURCE_SIZE > 0x71) THEN BEGIN // protects against invalid files
-+    LAUNCH_PATCH_MACRO ~clear~
-+	SET gradient = 232	// colour index
- 	SET location = wgrey		// location
- 	LAUNCH_PATCH_MACRO ~colour~
--	SET gradient = 248	// colour index
-+	SET gradient = 225	// colour index
- 	SET location = wred		// location
- 	LAUNCH_PATCH_MACRO ~colour~
--	SET gradient = 27	// colour index
-+	SET gradient = 248	// colour index
- 	SET location = wblue		// location
- 	LAUNCH_PATCH_MACRO ~colour~
+-   ACTION_FOR_EACH ~item~ IN ~dagg21~ ~dagg22~  BEGIN
++   /*ACTION_FOR_EACH ~item~ IN ~dagg21~ ~dagg22~  BEGIN //Dagger of the Star getting Shadow Thief Dagger icon
+     ACTION_IF (FILE_EXISTS_IN_GAME ~%item%.itm~) THEN BEGIN
+       COPY_EXISTING ~%item%.itm~ ~override~
+   PATCH_IF (SOURCE_SIZE > 0x71) THEN BEGIN // protects against invalid files
+@@ -72,7 +72,7 @@
+   END
+   BUT_ONLY_IF_IT_CHANGES
+ END
+-END
++END*/
+   
+   
+     ACTION_IF (FILE_EXISTS_IN_GAME ~demosum4.itm~) THEN BEGIN
+@@ -97,7 +97,7 @@
+     ACTION_IF (FILE_EXISTS_IN_GAME ~halb07.itm~) THEN BEGIN
+   COPY_EXISTING ~halb07.itm~ ~override~
+   WRITE_LONG  0x3E 0
+-  WRITE_ASCII 0x3A ~ihalb03~
++  WRITE_ASCII 0x3A ~ihalb07~
+   READ_LONG  0x6a "gfx_off"
+   READ_SHORT 0x70 "gfx_num"
+   WHILE ("%gfx_num%" > 0) BEGIN
+@@ -242,14 +242,14 @@
+     ACTION_IF (FILE_EXISTS_IN_GAME ~%item%.itm~) THEN BEGIN
+       COPY_EXISTING ~%item%.itm~ ~override~
+   WRITE_LONG  0x3E 0
+-  WRITE_ASCII 0x3A ~ISW1HRN~
++  WRITE_ASCII 0x3A ~ISW1H06~
+   READ_LONG  0x64 "abil_off"
+   READ_SHORT 0x68 "abil_num"
+   WHILE ("%abil_num%" > 0) BEGIN
+     READ_BYTE ("%abil_off%" + (0x38 * ("%abil_num%" - 1))) "type"
+     PATCH_IF ("%type%" = 1) BEGIN
+       WRITE_LONG  ("%abil_off%" + 0x08 + (0x38 * ("%abil_num%" - 1))) 0
+-      WRITE_ASCII ("%abil_off%" + 0x04 + (0x38 * ("%abil_num%" - 1))) ~ISW1HRN~
++      WRITE_ASCII ("%abil_off%" + 0x04 + (0x38 * ("%abil_num%" - 1))) ~ISW1H06~
      END
-   BUT_ONLY_IF_IT_CHANGES
+     SET "abil_num" = ("%abil_num%" - 1)
    END
+@@ -1421,51 +1421,51 @@
+   BUT_ONLY_IF_IT_CHANGES
+ END
    
--  ACTION_IF (FILE_EXISTS_IN_GAME ~_dagg09.itm~) THEN BEGIN
--COPY_EXISTING ~_dagg09.itm~ ~override~
-+	ACTION_IF (FILE_EXISTS_IN_GAME ~dagg11a.itm~) THEN BEGIN //IR compatibility
-+COPY_EXISTING ~dagg11a.itm~ ~override~
- PATCH_IF (SOURCE_SIZE > 0x71) THEN BEGIN // protects against invalid files
-     LAUNCH_PATCH_MACRO ~clear~
--	SET gradient = 228	// colour index
-+	SET gradient = 232	// colour index
- 	SET location = wgrey		// location
- 	LAUNCH_PATCH_MACRO ~colour~
--	SET gradient = 248	// colour index
-+	SET gradient = 225	// colour index
- 	SET location = wred		// location
- 	LAUNCH_PATCH_MACRO ~colour~
--	SET gradient = 27	// colour index
-+	SET gradient = 248	// colour index
- 	SET location = wblue		// location
- 	LAUNCH_PATCH_MACRO ~colour~
-     END
-   BUT_ONLY_IF_IT_CHANGES
-   END
-   
--	ACTION_IF (FILE_EXISTS_IN_GAME ~dagg10.itm~) THEN BEGIN
--COPY_EXISTING ~dagg10.itm~ ~override~
-+	ACTION_IF (FILE_EXISTS_IN_GAME ~dagg11b.itm~) THEN BEGIN //IR compatibility
-+COPY_EXISTING ~dagg11b.itm~ ~override~
- PATCH_IF (SOURCE_SIZE > 0x71) THEN BEGIN // protects against invalid files
-     LAUNCH_PATCH_MACRO ~clear~
--	SET gradient = 236	// colour index
-+	SET gradient = 232	// colour index
- 	SET location = wgrey		// location
- 	LAUNCH_PATCH_MACRO ~colour~
--	SET gradient = 227	// colour index
-+	SET gradient = 225	// colour index
- 	SET location = wred		// location
- 	LAUNCH_PATCH_MACRO ~colour~
--	SET gradient = 5	// colour index
-+	SET gradient = 248	// colour index
- 	SET location = wblue		// location
- 	LAUNCH_PATCH_MACRO ~colour~
-     END
-   BUT_ONLY_IF_IT_CHANGES
-   END
-   
--  ACTION_IF (FILE_EXISTS_IN_GAME ~_dagg10.itm~) THEN BEGIN
--COPY_EXISTING ~_dagg10.itm~ ~override~
-+	ACTION_IF (FILE_EXISTS_IN_GAME ~dagg12.itm~) THEN BEGIN
-+COPY_EXISTING ~dagg12.itm~ ~override~
- PATCH_IF (SOURCE_SIZE > 0x71) THEN BEGIN // protects against invalid files
-     LAUNCH_PATCH_MACRO ~clear~
--	SET gradient = 236	// colour index
-+	SET setr = 242
-+	SET setr = 152
-+	SET setr = 189
-+	SET speed = 0x78
-+	SET location = wblue		// location
-+	LAUNCH_PATCH_MACRO ~pulse~
-+	SET gradient = 195	// colour index
- 	SET location = wgrey		// location
- 	LAUNCH_PATCH_MACRO ~colour~
--	SET gradient = 227	// colour index
-+	SET gradient = 47	// colour index
- 	SET location = wred		// location
- 	LAUNCH_PATCH_MACRO ~colour~
--	SET gradient = 5	// colour index
-+	SET gradient = 70	// colour index
- 	SET location = wblue		// location
- 	LAUNCH_PATCH_MACRO ~colour~
-     END
-   BUT_ONLY_IF_IT_CHANGES
-   END
-   
--  
--	ACTION_IF (FILE_EXISTS_IN_GAME ~dagg11.itm~) THEN BEGIN
--COPY_EXISTING ~dagg11.itm~ ~override~
-+	ACTION_IF (FILE_EXISTS_IN_GAME ~dagg12a.itm~) THEN BEGIN //IR compatibility
-+COPY_EXISTING ~dagg12a.itm~ ~override~
- PATCH_IF (SOURCE_SIZE > 0x71) THEN BEGIN // protects against invalid files
-     LAUNCH_PATCH_MACRO ~clear~
--	SET gradient = 232	// colour index
-+	SET setr = 242
-+	SET setr = 152
-+	SET setr = 189
-+	SET speed = 0x78
-+	SET location = wblue		// location
-+	LAUNCH_PATCH_MACRO ~pulse~
-+	SET gradient = 195	// colour index
- 	SET location = wgrey		// location
- 	LAUNCH_PATCH_MACRO ~colour~
--	SET gradient = 225	// colour index
-+	SET gradient = 47	// colour index
- 	SET location = wred		// location
- 	LAUNCH_PATCH_MACRO ~colour~
--	SET gradient = 248	// colour index
-+	SET gradient = 70	// colour index
- 	SET location = wblue		// location
- 	LAUNCH_PATCH_MACRO ~colour~
-     END
-   BUT_ONLY_IF_IT_CHANGES
-   END
-   
--  
--	ACTION_IF (FILE_EXISTS_IN_GAME ~dagg12.itm~) THEN BEGIN
--COPY_EXISTING ~dagg12.itm~ ~override~
-+	ACTION_IF (FILE_EXISTS_IN_GAME ~dagg12b.itm~) THEN BEGIN //IR compatibility
-+COPY_EXISTING ~dagg12b.itm~ ~override~
- PATCH_IF (SOURCE_SIZE > 0x71) THEN BEGIN // protects against invalid files
-     LAUNCH_PATCH_MACRO ~clear~
- 	SET setr = 242
-@@ -7987,8 +8345,6 @@
-   BUT_ONLY_IF_IT_CHANGES
-   END
-   
--  
--  
-   ACTION_IF (FILE_EXISTS_IN_GAME ~dagg13.itm~) THEN BEGIN
- COPY_EXISTING ~dagg13.itm~ ~override~
- PATCH_IF (SOURCE_SIZE > 0x71) THEN BEGIN // protects against invalid files
-@@ -8160,6 +8516,23 @@
-   BUT_ONLY_IF_IT_CHANGES
-   END
-   
-+  ACTION_IF (FILE_EXISTS_IN_GAME ~dagg22a.itm~) THEN BEGIN //IR compatibility
-+COPY_EXISTING ~dagg22a.itm~ ~override~
-+PATCH_IF (SOURCE_SIZE > 0x71) THEN BEGIN // protects against invalid files
-+    LAUNCH_PATCH_MACRO ~clear~
-+	SET gradient = 211	// colour index
-+	SET location = wgrey		// location
-+	LAUNCH_PATCH_MACRO ~colour~
-+	SET gradient = 238	// colour index
-+	SET location = wred		// location
-+	LAUNCH_PATCH_MACRO ~colour~
-+	SET gradient = 212	// colour index
-+	SET location = wblue		// location
-+	LAUNCH_PATCH_MACRO ~colour~
-+    END
-+  BUT_ONLY_IF_IT_CHANGES
-+  END
-+  
-   ACTION_IF (FILE_EXISTS_IN_GAME ~dagg23.itm~) THEN BEGIN
- COPY_EXISTING ~dagg23.itm~ ~override~
- PATCH_IF (SOURCE_SIZE > 0x71) THEN BEGIN // protects against invalid files
-@@ -8433,6 +8806,50 @@
-     END
-   BUT_ONLY_IF_IT_CHANGES
-   END
-+  
-+  ACTION_IF (FILE_EXISTS_IN_GAME ~hamm06a.itm~) THEN BEGIN //IR compatibility
-+COPY_EXISTING ~hamm06a.itm~ ~override~
-+PATCH_IF (SOURCE_SIZE > 0x71) THEN BEGIN // protects against invalid files
-+    LAUNCH_PATCH_MACRO ~clear~
-+	SET setr = 0
-+	SET setg = 0
-+	SET setb = 0
-+	SET location = wblue		// location
-+	LAUNCH_PATCH_MACRO ~glow~
-+	SET gradient = 6	// colour index
-+	SET location = wgrey		// location
-+	LAUNCH_PATCH_MACRO ~colour~
-+	SET gradient = 253	// colour index
-+	SET location = wred		// location
-+	LAUNCH_PATCH_MACRO ~colour~
-+	SET gradient = 245	// colour index
-+	SET location = wblue		// location
-+	LAUNCH_PATCH_MACRO ~colour~
-+    END
-+  BUT_ONLY_IF_IT_CHANGES
-+  END
-+  
-+  ACTION_IF (FILE_EXISTS_IN_GAME ~hamm06b.itm~) THEN BEGIN //IR compatibility
-+COPY_EXISTING ~hamm06b.itm~ ~override~
-+PATCH_IF (SOURCE_SIZE > 0x71) THEN BEGIN // protects against invalid files
-+    LAUNCH_PATCH_MACRO ~clear~
-+	SET setr = 0
-+	SET setg = 0
-+	SET setb = 0
-+	SET location = wblue		// location
-+	LAUNCH_PATCH_MACRO ~glow~
-+	SET gradient = 6	// colour index
-+	SET location = wgrey		// location
-+	LAUNCH_PATCH_MACRO ~colour~
-+	SET gradient = 253	// colour index
-+	SET location = wred		// location
-+	LAUNCH_PATCH_MACRO ~colour~
-+	SET gradient = 245	// colour index
-+	SET location = wblue		// location
-+	LAUNCH_PATCH_MACRO ~colour~
-+    END
-+  BUT_ONLY_IF_IT_CHANGES
-+  END
-  
-  ACTION_IF (FILE_EXISTS_IN_GAME ~hamm07.itm~) THEN BEGIN
- COPY_EXISTING ~hamm07.itm~ ~override~
-@@ -8488,7 +8905,35 @@
-     END
-   BUT_ONLY_IF_IT_CHANGES
-   END
-- 
-+  
-+ ACTION_IF (FILE_EXISTS_IN_GAME ~hamm09a.itm~) THEN BEGIN //IR compatibility
-+COPY_EXISTING ~hamm09a.itm~ ~override~
-+PATCH_IF (SOURCE_SIZE > 0x71) THEN BEGIN // protects against invalid files
-+    LAUNCH_PATCH_MACRO ~clear~
-+	SET setr = 99
-+	SET setg = 199
-+	SET setb = 222
-+	SET speed = 0x32
-+	SET location = wblue		// location
-+	LAUNCH_PATCH_MACRO ~pulse~
-+	SET setr = 0
-+	SET setg = 0
-+	SET setb = 0
-+	SET location = wgrey		// location
-+	LAUNCH_PATCH_MACRO ~glow~
-+	SET gradient = 235	// colour index
-+	SET location = wgrey		// location
-+	LAUNCH_PATCH_MACRO ~colour~
-+	SET gradient = 249	// colour index
-+	SET location = wred		// location
-+	LAUNCH_PATCH_MACRO ~colour~
-+	SET gradient = 231	// colour index
-+	SET location = wblue		// location
-+	LAUNCH_PATCH_MACRO ~colour~
-+    END
-+  BUT_ONLY_IF_IT_CHANGES
-+  END
-+
-  ACTION_IF (FILE_EXISTS_IN_GAME ~hamm08.itm~) THEN BEGIN
- COPY_EXISTING ~hamm08.itm~ ~override~
- PATCH_IF (SOURCE_SIZE > 0x71) THEN BEGIN // protects against invalid files
-@@ -8532,13 +8977,13 @@
- 	SET speed = 0x28
- 	SET location = wgrey		// location
- 	LAUNCH_PATCH_MACRO ~pulse~
--	SET gradient = 209	// colour index
-+	SET gradient = 209	//93 colour index
- 	SET location = wgrey		// location
- 	LAUNCH_PATCH_MACRO ~colour~
--	SET gradient = 212	// colour index
-+	SET gradient = 212	//211 colour index
- 	SET location = wred		// location
- 	LAUNCH_PATCH_MACRO ~colour~
--	SET gradient = 212	// colour index
-+	SET gradient = 212	//90 colour index
- 	SET location = wblue		// location
- 	LAUNCH_PATCH_MACRO ~colour~
-     END
-@@ -8571,13 +9016,13 @@
- 	SET speed = 0x28
- 	SET location = wgrey		// location
- 	LAUNCH_PATCH_MACRO ~pulse~
--	SET gradient = 209	// colour index
-+	SET gradient = 209	//93 colour index
- 	SET location = wgrey		// location
- 	LAUNCH_PATCH_MACRO ~colour~
--	SET gradient = 212	// colour index
-+	SET gradient = 212	//211 colour index
- 	SET location = wred		// location
- 	LAUNCH_PATCH_MACRO ~colour~
--	SET gradient = 212	// colour index
-+	SET gradient = 212	//90 colour index
- 	SET location = wblue		// location
- 	LAUNCH_PATCH_MACRO ~colour~
-     END
-@@ -8974,6 +9419,15 @@
-     END
-   BUT_ONLY_IF_IT_CHANGES
-   END
-+
-+    ACTION_IF (FILE_EXISTS_IN_GAME ~bgmisc89.itm~) THEN BEGIN //BGT & IR compatibility
-+COPY_EXISTING ~bgmisc89.itm~ ~override~
-+PATCH_IF (SOURCE_SIZE > 0x71) THEN BEGIN // protects against invalid files
-+    WRITE_LONG  0x3E 0
-+    WRITE_ASCII 0x3A ~1AMUL07B~
-+    END
-+  BUT_ONLY_IF_IT_CHANGES
-+  END
-   
-   ACTION_IF (FILE_EXISTS_IN_GAME ~book68.itm~) THEN BEGIN
- COPY_EXISTING ~book68.itm~ ~override~
-@@ -10258,38 +10712,20 @@
-   BUT_ONLY_IF_IT_CHANGES
-   END
-   
--  ACTION_IF (FILE_EXISTS_IN_GAME ~sw1h31.itm~) THEN BEGIN
-+  ACTION_IF (FILE_EXISTS_IN_GAME ~sw1h31.itm~) THEN BEGIN //swap Albruin and Daystar back
+-      ACTION_IF (FILE_EXISTS_IN_GAME ~sw1h31.itm~) THEN BEGIN
++/*      ACTION_IF (FILE_EXISTS_IN_GAME ~sw1h31.itm~) THEN BEGIN //Daystar's icon being set to Albruin's for no apparent reason
  COPY_EXISTING ~sw1h31.itm~ ~override~
- PATCH_IF (SOURCE_SIZE > 0x71) THEN BEGIN // protects against invalid files
-     // WRITE_ASCII 0x22 ~S0~
-     // WRITE_LONG  0x3E 0
-     // WRITE_ASCII 0x3A ~~
- 	LAUNCH_PATCH_MACRO ~clear~
--	SET setr = 0
--	SET setg = 160
--	SET setb = 191
--	SET speed = 0x3f
--	SET location = wgrey		// location
--	LAUNCH_PATCH_MACRO ~pulse~
--	SET setr = 255
--	SET setg = 255
--	SET setb = 53
--	SET speed = 0x3c
--	SET location = wblue		// location
--	LAUNCH_PATCH_MACRO ~pulse~
--	SET setr = 199
--	SET setg = 199
--	SET setb = 39
--	SET speed = 0x3c
--	SET location = wred		// location
--	LAUNCH_PATCH_MACRO ~pulse~
--	SET gradient = 90	// colour index
-+	SET gradient = 250	// colour index
- 	SET location = wgrey		// location
- 	LAUNCH_PATCH_MACRO ~colour~
--	SET gradient = 179	// colour index
-+	SET gradient = 226	// colour index
- 	SET location = wblue		// location
- 	LAUNCH_PATCH_MACRO ~colour~
--	SET gradient = 120	// colour index
-+	SET gradient = 224	// colour index
- 	SET location = wred		// location
- 	LAUNCH_PATCH_MACRO ~colour~
+   WRITE_LONG  0x3E 0
+-  WRITE_ASCII 0x3A ~ISW1H34~
++  WRITE_ASCII 0x3A ~ISW1H31~
+   READ_LONG  0x64 "abil_off"
+   READ_SHORT 0x68 "abil_num"
+   WHILE ("%abil_num%" > 0) BEGIN
+     READ_BYTE ("%abil_off%" + (0x38 * ("%abil_num%" - 1))) "type"
+     PATCH_IF ("%type%" = 1) BEGIN
+       WRITE_LONG  ("%abil_off%" + 0x08 + (0x38 * ("%abil_num%" - 1))) 0
+-      WRITE_ASCII ("%abil_off%" + 0x04 + (0x38 * ("%abil_num%" - 1))) ~ISW1H34~
++      WRITE_ASCII ("%abil_off%" + 0x04 + (0x38 * ("%abil_num%" - 1))) ~ISW1H31~
      END
-@@ -10322,20 +10758,38 @@
-   BUT_ONLY_IF_IT_CHANGES
+     SET "abil_num" = ("%abil_num%" - 1)
    END
+   BUT_ONLY_IF_IT_CHANGES
+ END
    
--  ACTION_IF (FILE_EXISTS_IN_GAME ~sw1h34.itm~) THEN BEGIN
-+  ACTION_IF (FILE_EXISTS_IN_GAME ~sw1h34.itm~) THEN BEGIN //swap Albruin and Daystar back
+-      ACTION_IF (FILE_EXISTS_IN_GAME ~sw1h34.itm~) THEN BEGIN
++      ACTION_IF (FILE_EXISTS_IN_GAME ~sw1h34.itm~) THEN BEGIN //Albruin's icon being set to Daystar's for no apparent reason
  COPY_EXISTING ~sw1h34.itm~ ~override~
- PATCH_IF (SOURCE_SIZE > 0x71) THEN BEGIN // protects against invalid files
-     WRITE_ASCII 0x22 ~S0~
-     // WRITE_LONG  0x3E 0
-     // WRITE_ASCII 0x3A ~~
- 	LAUNCH_PATCH_MACRO ~clear~
--	SET gradient = 250	// colour index
-+	SET setr = 0
-+	SET setg = 160
-+	SET setb = 191
-+	SET speed = 0x3f
-+	SET location = wgrey		// location
-+	LAUNCH_PATCH_MACRO ~pulse~
-+	SET setr = 255
-+	SET setg = 255
-+	SET setb = 53
-+	SET speed = 0x3c
-+	SET location = wblue		// location
-+	LAUNCH_PATCH_MACRO ~pulse~
-+	SET setr = 199
-+	SET setg = 199
-+	SET setb = 39
-+	SET speed = 0x3c
-+	SET location = wred		// location
-+	LAUNCH_PATCH_MACRO ~pulse~
-+	SET gradient = 90	// colour index
- 	SET location = wgrey		// location
- 	LAUNCH_PATCH_MACRO ~colour~
--	SET gradient = 226	// colour index
-+	SET gradient = 179	// colour index
- 	SET location = wblue		// location
- 	LAUNCH_PATCH_MACRO ~colour~
--	SET gradient = 224	// colour index
-+	SET gradient = 120	// colour index
- 	SET location = wred		// location
- 	LAUNCH_PATCH_MACRO ~colour~
+   WRITE_LONG  0x3E 0
+-  WRITE_ASCII 0x3A ~ISW1H31~
++  WRITE_ASCII 0x3A ~ISW1H34~
+   READ_LONG  0x64 "abil_off"
+   READ_SHORT 0x68 "abil_num"
+   WHILE ("%abil_num%" > 0) BEGIN
+     READ_BYTE ("%abil_off%" + (0x38 * ("%abil_num%" - 1))) "type"
+     PATCH_IF ("%type%" = 1) BEGIN
+       WRITE_LONG  ("%abil_off%" + 0x08 + (0x38 * ("%abil_num%" - 1))) 0
+-      WRITE_ASCII ("%abil_off%" + 0x04 + (0x38 * ("%abil_num%" - 1))) ~ISW1H31~
++      WRITE_ASCII ("%abil_off%" + 0x04 + (0x38 * ("%abil_num%" - 1))) ~ISW1H34~
      END
-@@ -11016,6 +11470,25 @@
-   BUT_ONLY_IF_IT_CHANGES
+     SET "abil_num" = ("%abil_num%" - 1)
    END
-   
-+  ACTION_IF (FILE_EXISTS_IN_GAME ~sw2h13.itm~) THEN BEGIN //Spider's Bane #2
-+COPY_EXISTING ~sw2h13.itm~ ~override~
-+PATCH_IF (SOURCE_SIZE > 0x71) THEN BEGIN // protects against invalid files
-+    // WRITE_LONG  0x3E 0
-+    // WRITE_ASCII 0x3A ~~
-+	LAUNCH_PATCH_MACRO ~clear~
-+	SET gradient = 186	// colour index
-+	SET location = wgrey		// location
-+	LAUNCH_PATCH_MACRO ~colour~
-+	SET gradient = 5	// colour index
-+	SET location = wblue		// location
-+	LAUNCH_PATCH_MACRO ~colour~
-+	SET gradient = 209	// colour index
-+	SET location = wred		// location
-+	LAUNCH_PATCH_MACRO ~colour~
-+    END
-+  BUT_ONLY_IF_IT_CHANGES
-+  END
-+  
-   ACTION_IF (FILE_EXISTS_IN_GAME ~sw2h07.itm~) THEN BEGIN
- COPY_EXISTING ~sw2h07.itm~ ~override~
- PATCH_IF (SOURCE_SIZE > 0x71) THEN BEGIN // protects against invalid files
-@@ -11655,9 +12128,9 @@
- 
- STATISTICS:
- 
--Damage:  1D8 +2
--THAC0:  +2 bonus
--Damage type:  slashing
-+Damage: 1D8 +2
-+THAC0: +2 bonus
-+Damage type: slashing
- Weight: 3
- Speed Factor: 3
- Proficiency Type: Long Sword
-@@ -12463,17 +12936,17 @@
    BUT_ONLY_IF_IT_CHANGES
-   END
+-END
++END*/
    
--  ACTION_IF (FILE_EXISTS_IN_GAME ~blun16.itm~) THEN BEGIN
--COPY_EXISTING ~blun16.itm~ ~override~
-+  ACTION_IF (FILE_EXISTS_IN_GAME ~waflail.itm~) THEN BEGIN // originally blun16, but it overwrote the description and erroneously turned it into a flail - better to use on waflail instead
-+COPY_EXISTING ~waflail.itm~ ~override~
- PATCH_IF (SOURCE_SIZE > 0x71) THEN BEGIN // protects against invalid files
- 	WRITE_ASCII 0x22 ~F0~
- 	WRITE_LONG  0x8 0x1a30
- 	WRITE_LONG  0x50 0x1a32
- 	WRITE_SHORT  0x1c 0x17
--     // WRITE_LONG  0x3E 0
--     // WRITE_ASCII 0x3A ~IBLUN13B~
--	 // WRITE_LONG  0x7A 0
--     // WRITE_ASCII 0x76 ~IBLUN13B~
-+    WRITE_LONG  0x3E 0
-+    WRITE_ASCII 0x3A ~WAFLAIL~
-+	WRITE_LONG  0x7A 0
-+    WRITE_ASCII 0x76 ~WAFLAIL~
- 	LAUNCH_PATCH_MACRO ~clear~
- 	SET gradient = 90	// colour index
- 	SET location = wgrey		// location
-@@ -12484,7 +12957,7 @@
- 	SET gradient = 245	// colour index
- 	SET location = wblue		// location
- 	LAUNCH_PATCH_MACRO ~colour~
--	SAY DESC ~War Flail + 2: The Sleeper
-+	/*SAY DESC ~War Flail + 2: The Sleeper
- This belonged to Ssitalc, an uncharacteristically evil elf known as the Slaver of the Sword Coast.  Until his sudden death several years ago, Ssitalc commanded a large force of human, dwarf and gnomish brigands, using the Sleeper to keep them in line.  It has a chance to incapacitate any human, dwarf, gnome, or halfling by inducing deep slumber, though elves are conveniently immune.
- 
- STATISTICS
-@@ -12501,7 +12974,7 @@
- Not Usable By:
-  Druid
-  Mage 
-- Thief~ 
-+ Thief~*/ 
+       ACTION_IF (FILE_EXISTS_IN_GAME ~sw1h41.itm~) THEN BEGIN
+ COPY_EXISTING ~sw1h41.itm~ ~override~
+   WRITE_LONG  0x3E 0
+-  WRITE_ASCII 0x3A ~ISW1H06~
++  WRITE_ASCII 0x3A ~ISW1H41~
+   READ_LONG  0x64 "abil_off"
+   READ_SHORT 0x68 "abil_num"
+   WHILE ("%abil_num%" > 0) BEGIN
+     READ_BYTE ("%abil_off%" + (0x38 * ("%abil_num%" - 1))) "type"
+     PATCH_IF ("%type%" = 1) BEGIN
+       WRITE_LONG  ("%abil_off%" + 0x08 + (0x38 * ("%abil_num%" - 1))) 0
+-      WRITE_ASCII ("%abil_off%" + 0x04 + (0x38 * ("%abil_num%" - 1))) ~ISW1H06~
++      WRITE_ASCII ("%abil_off%" + 0x04 + (0x38 * ("%abil_num%" - 1))) ~ISW1H41~
      END
-   BUT_ONLY_IF_IT_CHANGES
+     SET "abil_num" = ("%abil_num%" - 1)
    END
-@@ -14887,8 +15360,8 @@
- 	SET gradient = 99	// colour index
- 	SET location = ablue		// location
- 	LAUNCH_PATCH_MACRO ~colour~
--	SAY NAME2 ~Plate Mail +3~ 
--  SAY DESC ~Plate Mail +3 : 'The Practical Defense'
-+/*	SAY NAME2 ~Plate Mail +3~ //unnecessary text overwrite
-+  SAY DESC ~Plate Mail +3: The Practical Defense
- The traveling adventurer could ask for no better a suit of armor in all the land. Specially commissioned by Bolhur "Thunderaxe" at GREAT expense, this suit was his most prized, even if not his most ornate. Eminently practical, Bolhur demanded armor that would offer superior protection while hampering him in the least. By "hampering" he did not just mean in movement or weight, though this suit is just over one-third the weight of normal plate mail: his ideal suit should also be able to withstand the rigors of his wanderings with little maintenance. This is not to say that Bolhur "Thunderaxe" neglected his armors (to say as such would get your ears boxed) but the regime of spit and polish required for a "gentleman's" suit was beyond his caring. Save the tassels and gilding of Full Plate for kings and heads of state; a working dwarf cares more for utility than looks.
- 
- STATISTICS:
-@@ -14900,7 +15373,7 @@
-  Bard
-  Druid
-  Mage
-- Thief~ 
-+ Thief~*/ 
-     END
+@@ -1603,19 +1603,19 @@
    BUT_ONLY_IF_IT_CHANGES
-   END
-@@ -15192,7 +15665,7 @@
- 	SET gradient = 97	// colour index
- 	SET location = ablue		// location
- 	LAUNCH_PATCH_MACRO ~colour~
--    SAY DESC ~Chain mail +2:  'Werebane'
-+    SAY DESC ~Chain Mail +2: Werebane
- These magical sets of silver chain mail were commissioned and worn by a virtuous band of paladins who set out to rid the world of the blight of lycanthropy. The continued presence of lycanthropes in the realms and the appearance of these sets of armour in mercantile stocks suggests they were less than successful.
- 
- STATISTICS:
-@@ -15268,7 +15741,7 @@
-   BUT_ONLY_IF_IT_CHANGES
-   END
+ END
    
--  ACTION_IF (FILE_EXISTS_IN_GAME ~plat14.itm~) THEN BEGIN
-+  /*ACTION_IF (FILE_EXISTS_IN_GAME ~plat14.itm~) THEN BEGIN //let it remain vanilla (better looking)
- COPY_EXISTING ~plat14.itm~ ~override~
- PATCH_IF (SOURCE_SIZE > 0x71) THEN BEGIN // protects against invalid files
-     // WRITE_ASCII 0x22 ~~
-@@ -15286,14 +15759,14 @@
- 	LAUNCH_PATCH_MACRO ~colour~
-     END
-   BUT_ONLY_IF_IT_CHANGES
--  END
-+  END*/
-   
-   ACTION_IF (FILE_EXISTS_IN_GAME ~plat15.itm~) THEN BEGIN
- COPY_EXISTING ~plat15.itm~ ~override~
- PATCH_IF (SOURCE_SIZE > 0x71) THEN BEGIN // protects against invalid files
-     // WRITE_ASCII 0x22 ~~
+-  ACTION_FOR_EACH ~item~ IN ~sw2h10~ ~sw2h19~    BEGIN
++  ACTION_FOR_EACH ~item~ IN ~sw2h10~ ~sw2h19~    BEGIN //Why was this being set to ISW2H20? ...
+     ACTION_IF (FILE_EXISTS_IN_GAME ~%item%.itm~) THEN BEGIN
+       COPY_EXISTING ~%item%.itm~ ~override~
+   PATCH_IF (SOURCE_SIZE > 0x71) THEN BEGIN // protects against invalid files
      WRITE_LONG  0x3E 0
--    WRITE_ASCII 0x3A ~IPLAT23~
-+    WRITE_ASCII 0x3A ~IPLAT15~ //seems like an error that it was set to iplat23
- 	LAUNCH_PATCH_MACRO ~clear~
- 	SET gradient = 91	// colour index
- 	SET location = agrey		// location
-@@ -15328,12 +15801,14 @@
-   BUT_ONLY_IF_IT_CHANGES
+-    WRITE_ASCII 0x3A ~ISW2H20~
++    WRITE_ASCII 0x3A ~ISW2H10~
+     READ_LONG  0x64 "abil_off"
+     READ_SHORT 0x68 "abil_num"
+     WHILE ("%abil_num%" > 0) BEGIN
+       READ_BYTE ("%abil_off%" + (0x38 * ("%abil_num%" - 1))) "type"
+       PATCH_IF ("%type%" = 1) BEGIN
+         WRITE_LONG  ("%abil_off%" + 0x08 + (0x38 * ("%abil_num%" - 1))) 0
+-        WRITE_ASCII ("%abil_off%" + 0x04 + (0x38 * ("%abil_num%" - 1))) ~ISW2H20~
++        WRITE_ASCII ("%abil_off%" + 0x04 + (0x38 * ("%abil_num%" - 1))) ~ISW2H10~
+       END
+       SET "abil_num" = ("%abil_num%" - 1)
+     END
+@@ -1627,14 +1627,14 @@
+    ACTION_IF (FILE_EXISTS_IN_GAME ~sw2h11.itm~) THEN BEGIN
+ COPY_EXISTING ~sw2h11.itm~ ~override~
+   WRITE_LONG  0x3E 0
+-  WRITE_ASCII 0x3A ~ISW2H03~
++  WRITE_ASCII 0x3A ~ISW2H11~
+   READ_LONG  0x64 "abil_off"
+   READ_SHORT 0x68 "abil_num"
+   WHILE ("%abil_num%" > 0) BEGIN
+     READ_BYTE ("%abil_off%" + (0x38 * ("%abil_num%" - 1))) "type"
+     PATCH_IF ("%type%" = 1) BEGIN
+       WRITE_LONG  ("%abil_off%" + 0x08 + (0x38 * ("%abil_num%" - 1))) 0
+-      WRITE_ASCII ("%abil_off%" + 0x04 + (0x38 * ("%abil_num%" - 1))) ~ISW2H03~
++      WRITE_ASCII ("%abil_off%" + 0x04 + (0x38 * ("%abil_num%" - 1))) ~ISW2H11~
+     END
+     SET "abil_num" = ("%abil_num%" - 1)
    END
-   
--   ACTION_IF (FILE_EXISTS_IN_GAME ~plat23.itm~) THEN BEGIN
-+   /*ACTION_IF (FILE_EXISTS_IN_GAME ~plat23.itm~) THEN BEGIN //let it remain vanilla (better looking)
- COPY_EXISTING ~plat23.itm~ ~override~
- PATCH_IF (SOURCE_SIZE > 0x71) THEN BEGIN // protects against invalid files
-     // WRITE_ASCII 0x22 ~~
+@@ -1645,14 +1645,14 @@
+ COPY_EXISTING ~sw2h20.itm~ ~override~
+   PATCH_IF (SOURCE_SIZE > 0x71) THEN BEGIN // protects against invalid files
      WRITE_LONG  0x3E 0
-     WRITE_ASCII 0x3A ~1plat05~
-+    WRITE_LONG  0x5C 0
-+    WRITE_ASCII 0x58 ~CPLAT16~
- 	LAUNCH_PATCH_MACRO ~clear~
- 	SET gradient = 209	// colour index
- 	SET location = agrey		// location
-@@ -15346,7 +15821,7 @@
- 	LAUNCH_PATCH_MACRO ~colour~
+-    WRITE_ASCII 0x3A ~ISW2H06~
++    WRITE_ASCII 0x3A ~ISW2H20~
+     READ_LONG  0x64 "abil_off"
+     READ_SHORT 0x68 "abil_num"
+     WHILE ("%abil_num%" > 0) BEGIN
+       READ_BYTE ("%abil_off%" + (0x38 * ("%abil_num%" - 1))) "type"
+       PATCH_IF ("%type%" = 1) BEGIN
+         WRITE_LONG  ("%abil_off%" + 0x08 + (0x38 * ("%abil_num%" - 1))) 0
+-        WRITE_ASCII ("%abil_off%" + 0x04 + (0x38 * ("%abil_num%" - 1))) ~ISW2H06~
++        WRITE_ASCII ("%abil_off%" + 0x04 + (0x38 * ("%abil_num%" - 1))) ~ISW2H20~
+       END
+       SET "abil_num" = ("%abil_num%" - 1)
      END
-   BUT_ONLY_IF_IT_CHANGES
--  END
-+  END*/
-   
- 
-   ACTION_IF (FILE_EXISTS_IN_GAME ~plat09.itm~) THEN BEGIN
-@@ -15374,7 +15849,7 @@
- PATCH_IF (SOURCE_SIZE > 0x71) THEN BEGIN // protects against invalid files
-     // WRITE_ASCII 0x22 ~~
-     WRITE_LONG  0x5C 0
--    WRITE_ASCII 0x58 ~CPLAT04~
-+    WRITE_ASCII 0x58 ~CPLAT09~ //used to be CPLAT04, but CPLAT09 seems more correct
-     END
-   BUT_ONLY_IF_IT_CHANGES
-   END
-@@ -15384,7 +15859,7 @@
- PATCH_IF (SOURCE_SIZE > 0x71) THEN BEGIN // protects against invalid files
-     // WRITE_ASCII 0x22 ~~
-     WRITE_LONG  0x5C 0
--    WRITE_ASCII 0x58 ~CPLAT05~
-+    WRITE_ASCII 0x58 ~CPLAT15~ //used to be CPLAT05, but CPLAT15 seems more correct
-     END
-   BUT_ONLY_IF_IT_CHANGES
-   END
-@@ -15398,6 +15873,28 @@
-     END
-   BUT_ONLY_IF_IT_CHANGES
-   END
-+
-+   ACTION_IF (FILE_EXISTS_IN_GAME ~plat19.itm~) THEN BEGIN //might as well use something unused
-+COPY_EXISTING ~plat19.itm~ ~override~
-+PATCH_IF (SOURCE_SIZE > 0x71) THEN BEGIN // protects against invalid files
-+    // WRITE_ASCII 0x22 ~~
-+    WRITE_LONG  0x5C 0
-+    WRITE_ASCII 0x58 ~CPLAT16~
-+    WRITE_LONG  0x3E 0
-+     WRITE_ASCII 0x3A ~IPLAT13~
-+	LAUNCH_PATCH_MACRO ~clear~
-+	SET gradient = 226	// colour index
-+	SET location = agrey		// location
-+	LAUNCH_PATCH_MACRO ~colour~
-+	SET gradient = 24	// colour index
-+	SET location = ared		// location
-+	LAUNCH_PATCH_MACRO ~colour~
-+	SET gradient = 110	// colour index
-+	SET location = ablue		// location
-+	LAUNCH_PATCH_MACRO ~colour~
-+    END
-+  BUT_ONLY_IF_IT_CHANGES
-+  END
-   
-     ACTION_IF (FILE_EXISTS_IN_GAME ~plat22.itm~) THEN BEGIN
- COPY_EXISTING ~plat22.itm~ ~override~
-@@ -16099,7 +16596,7 @@
-     LAUNCH_PATCH_MACRO ADD_AREA_ITEM
-    
-    COPY_EXISTING ~ar0203.are~ ~override~ 
--     SPRINT ~item_to_add~  ~BAND03~
-+     SPRINT ~item_to_add~  ~XOBAND03~
-     SET container_to_add_to = 1
-     SET charges1 = 0
-     SET charges2 = 0
-@@ -16107,7 +16604,7 @@
-     LAUNCH_PATCH_MACRO ADD_AREA_ITEM
-    
-      COPY_EXISTING ~ar1403.are~ ~override~ 
--     SPRINT ~item_to_add~  ~BAND04~
-+     SPRINT ~item_to_add~  ~XOBAND04~
-     SET container_to_add_to = 1
-     SET charges1 = 0
-     SET charges2 = 0
-@@ -16136,28 +16633,28 @@
-     ADD_STORE_ITEM ~helm22~   AFTER  ~amul10~ #0 #0 #0 ~IDENTIFIED~ #1
-    
-     COPY_EXISTING ~dshop02.sto~ ~override~ 
--    ADD_STORE_ITEM ~band01~   AFTER  ~potn20~ #0 #0 #0 ~IDENTIFIED~ #1
-+    ADD_STORE_ITEM ~xoband01~ AFTER  ~potn20~ #0 #0 #0 ~IDENTIFIED~ #1
-    
-    COPY_EXISTING ~dshop02.sto~ ~override~ 
--    ADD_STORE_ITEM ~band01~   AFTER  ~potn20~ #0 #0 #0 ~IDENTIFIED~ #1
-+    ADD_STORE_ITEM ~xoband01~ AFTER  ~potn20~ #0 #0 #0 ~IDENTIFIED~ #1
- 	
- 	COPY_EXISTING ~bmthief.sto~ ~override~ 
--    ADD_STORE_ITEM ~band01~   AFTER  ~dagg16~ #0 #0 #0 ~IDENTIFIED~ #1
-+    ADD_STORE_ITEM ~xoband01~ AFTER  ~dagg16~ #0 #0 #0 ~IDENTIFIED~ #1
-    
-    COPY_EXISTING ~bernard.sto~ ~override~ 
--    ADD_STORE_ITEM ~band01~   AFTER  ~amul13~ #0 #0 #0 ~IDENTIFIED~ #2
-+    ADD_STORE_ITEM ~xoband01~ AFTER  ~amul13~ #0 #0 #0 ~IDENTIFIED~ #2
-    
-    COPY_EXISTING ~bmthief.sto~ ~override~ 
--    ADD_STORE_ITEM ~band01~   AFTER  ~dagg16~ #0 #0 #0 ~IDENTIFIED~ #1
-+    ADD_STORE_ITEM ~xoband01~ AFTER  ~dagg16~ #0 #0 #0 ~IDENTIFIED~ #1
-    
-      COPY_EXISTING ~govwau01.sto~ ~override~ 
--    ADD_STORE_ITEM ~band02~   BEFORE  ~potn08~ #0 #0 #0 ~IDENTIFIED~ #1
-+    ADD_STORE_ITEM ~xoband02~ BEFORE  ~potn08~ #0 #0 #0 ~IDENTIFIED~ #1
- 	
- 	COPY_EXISTING ~uddrow23.sto~ ~override~ 
--    ADD_STORE_ITEM ~band02~   AFTER  ~amul10~ #0 #0 #0 ~IDENTIFIED~ #2
-+    ADD_STORE_ITEM ~xoband02~ AFTER  ~amul10~ #0 #0 #0 ~IDENTIFIED~ #2
-    
-    COPY_EXISTING ~ppumb01.sto~ ~override~ 
--    ADD_STORE_ITEM ~band02~   BEFORE  ~potn08~ #0 #0 #0 ~IDENTIFIED~ #1
-+    ADD_STORE_ITEM ~xoband02~ BEFORE  ~potn08~ #0 #0 #0 ~IDENTIFIED~ #1
-    
-    
-      END // game is
-@@ -16263,13 +16760,13 @@
-  
-      ACTION_IF (GAME_IS ~bg2 tob~) BEGIN
-    
--   COPY_EXISTING ~ar1006.are~ ~override~ 
--     SPRINT ~item_to_add~  ~SW1HWK~
-+   /*COPY_EXISTING ~ar1006.are~ ~override~ 
-+     SPRINT ~item_to_add~  ~SW1HWK~ //weird weapon addition - disable?
-     SET container_to_add_to = 2
-     SET charges1 = 0
-     SET charges2 = 0
-     SET charges3 = 0
--    LAUNCH_PATCH_MACRO ADD_AREA_ITEM
-+    LAUNCH_PATCH_MACRO ADD_AREA_ITEM*/
-    
-    ACTION_IF (FILE_EXISTS_IN_GAME ~pstafm1.itm~) THEN BEGIN
-    COPY_EXISTING ~ar2100.are~ ~override~ 
-@@ -16281,7 +16778,7 @@
-     LAUNCH_PATCH_MACRO ADD_AREA_ITEM
-    END
-    
--   COPY_EXISTING ~ar0414.are~ ~override~ 
-+   /*COPY_EXISTING ~ar0414.are~ ~override~ 
-    LPF fj_are_structure
-     INT_VAR
-     fj_type        = 8 //nonvisible
-@@ -16316,10 +16813,10 @@
-     STR_VAR
-     fj_name           = sw1p01
-     fj_structure_type = itm
--  END
-+  END*/
-    
-    
--   COPY_EXISTING ~uddrow22.sto~ ~override~ 
-+   /*COPY_EXISTING ~uddrow22.sto~ ~override~ //on second thought, let's not mess around with stores
-    REMOVE_STORE_ITEM ~ax1h01~
-    REMOVE_STORE_ITEM ~ax1h04~
-    REMOVE_STORE_ITEM ~blun01~
-@@ -16380,7 +16877,7 @@
- REMOVE_STORE_ITEM ~sw1h04~ 
- REMOVE_STORE_ITEM ~sw1h05~
- REMOVE_STORE_ITEM ~sw1h43~
--REMOVE_STORE_ITEM ~xbow04~    
-+REMOVE_STORE_ITEM ~xbow04~    */
-         END // game is
- 	 
- 	 ACTION_IF (GAME_IS ~tutu tutu_totsc~) BEGIN
+@@ -1666,14 +1666,14 @@
+ COPY ~1pp/item/v2_copy/cshld19.bam~  ~override~
+ COPY ~1pp/item/v2_copy/cshld20.bam~  ~override~
+ COPY ~1pp/item/v2_copy/iax1h01.bam~  ~override~
+-COPY ~1pp/item/v2_copy/iax1h14.bam~  ~override~
++//COPY ~1pp/item/v2_copy/iax1h14.bam~  ~override~ //Axe of the Unyielding getting weird IWD icon
+ COPY ~1pp/item/v2_copy/iblun01.bam~  ~override~
+ COPY ~1pp/item/v2_copy/iblun04.bam~  ~override~
+ COPY ~1pp/item/v2_copy/iblun05.bam~  ~override~
+ COPY ~1pp/item/v2_copy/iblun06.bam~  ~override~
+ COPY ~1pp/item/v2_copy/iblun26.bam~  ~override~
+ COPY ~1pp/item/v2_copy/ibolts01.bam~ ~override~
+-COPY ~1pp/item/v2_copy/ibow26.bam~ ~override~
++//COPY ~1pp/item/v2_copy/ibow26.bam~ ~ibow26b.bam~ //Short Bow +3 getting weird IWD icon
+ COPY ~1pp/item/v2_copy/ichan04.bam~  ~override~
+ COPY ~1pp/item/v2_copy/ichan05.bam~  ~override~
+ COPY ~1pp/item/v2_copy/ichan07.bam~  ~override~
+@@ -1690,18 +1690,18 @@
+ COPY ~1pp/item/v2_copy/iclck15.bam~  ~override~
+ COPY ~1pp/item/v2_copy/iclck16.bam~  ~override~
+ COPY ~1pp/item/v2_copy/iclck17.bam~  ~override~
+-COPY ~1pp/item/v2_copy/idagg11.bam~  ~override~
++//COPY ~1pp/item/v2_copy/idagg11.bam~  ~override~ //Overwriting Boomerang Dagger's icon with Dagger of Venom's for no reason
+ COPY ~1pp/item/v2_copy/ihalb03.bam~  ~override~
+ COPY ~1pp/item/v2_copy/ihalb10.bam~  ~override~
+ COPY ~1pp/item/v2_copy/ihalb12.bam~  ~override~
+-COPY ~1pp/item/v2_copy/ihamm10.bam~  ~override~
++COPY ~1pp/item/v2_copy/ihamm10.bam~  ~override/ihamm11.bam~ //Save vanilla's Runehammer icon
+ COPY ~1pp/item/v2_copy/ihelm00.bam~  ~override~
+ COPY ~1pp/item/v2_copy/ihelm01.bam~  ~override~
+ COPY ~1pp/item/v2_copy/ihelm02.bam~  ~override~
+ COPY ~1pp/item/v2_copy/ihelm03.bam~  ~override~
+ COPY ~1pp/item/v2_copy/ihelm04.bam~  ~override~
+ COPY ~1pp/item/v2_copy/ihelm05.bam~  ~override~
+-COPY ~1pp/item/v2_copy/ihelm06.bam~  ~override~
++//COPY ~1pp/item/v2_copy/ihelm06.bam~  ~override~ //Roranach's Horn getting weird IWD icon
+ COPY ~1pp/item/v2_copy/ihelm07.bam~  ~override~
+ COPY ~1pp/item/v2_copy/ihelm14.bam~  ~override~
+ COPY ~1pp/item/v2_copy/ihelm31.bam~  ~override~
+@@ -1709,7 +1709,7 @@
+ COPY ~1pp/item/v2_copy/ileat01.bam~  ~override~
+ COPY ~1pp/item/v2_copy/ileat04.bam~  ~override~
+ COPY ~1pp/item/v2_copy/iplat01.bam~  ~override~
+-COPY ~1pp/item/v2_copy/iplat09.bam~  ~override~
++COPY ~1pp/item/v2_copy/iplat09.bam~  ~override/1plat02.bam~
+ COPY ~1pp/item/v2_copy/iplot01f.bam~ ~override~
+ COPY ~1pp/item/v2_copy/iqbull02.bam~ ~override~
+ COPY ~1pp/item/v2_copy/iquiv01.bam~  ~override~
+@@ -1723,7 +1723,7 @@
+ COPY ~1pp/item/v2_copy/ishldvr.bam~  ~override~
+ COPY ~1pp/item/v2_copy/ishldzs.bam~  ~override~
+ COPY ~1pp/item/v2_copy/isw1h02.bam~  ~override~
+-COPY ~1pp/item/v2_copy/isw1h06.bam~  ~override~
++//COPY ~1pp/item/v2_copy/isw1h06.bam~  ~override~ //Unnecessary overwrite - duplicate of isw1h72
+ COPY ~1pp/item/v2_copy/isw1h16.bam~  ~override~
+ COPY ~1pp/item/v2_copy/isw1h42.bam~  ~override~
+ COPY ~1pp/item/v2_copy/isw1h51.bam~  ~override~
+@@ -1749,9 +1749,9 @@
+ COPY ~1pp/item/v2_copy/isw1h77.bam~  ~override~
+ COPY ~1pp/item/v2_copy/isw1hbs.bam~  ~override~
+ COPY ~1pp/item/v2_copy/isw1hrc.bam~  ~override~
+-COPY ~1pp/item/v2_copy/isw1hrn.bam~  ~override~
++COPY ~1pp/item/v2_copy/isw1hrn.bam~  ~override/isw1h06.bam~ //Original place
+ COPY ~1pp/item/v2_copy/isw1hwk.bam~  ~override~
+-COPY ~1pp/item/v2_copy/isw2h07.bam~  ~override~
++COPY ~1pp/item/v2_copy/isw2h07.bam~  ~override/isw2h16.bam~ //Prevent Harbinger from losing its golden icon (which is what it's colored for anyway)
+ COPY ~1pp/item/v2_copy/isw2h17.bam~  ~override~
+ COPY ~1pp/item/v2_copy/isw2h20.bam~  ~override~
+ COPY ~1pp/item/v2_copy/iwand01.bam~  ~override~


### PR DESCRIPTION
using github makes me want to hurt myself

1.03a: Fixed a bunch of miscellaneous stuff in the v2 core component. Additionally, made sure both versions of Spider's Bane are consistent with each other, fixed a few incorrectly assigned plate icons along with a bunch of incorrectly assigned description icons, a compatibility fix for IR/R for Scimitar +3 and Sword of Flame +1, a fix for Helm of Defense, and the restoration of Harbinger's icon that was mysteriously getting overwritten.

1.03b: Fixed Boomerang Dagger getting its icon overwritten for no reason and Long Sword +2 having its colors set to that of Long Sword +3's.